### PR TITLE
Add Github issue comment RDF export

### DIFF
--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
@@ -833,6 +833,10 @@ public class GithubRdfConversionTransactionService {
                             }
                         }
 
+                        if (githubIssueRepositoryFilter.isEnableIssueComments()) {
+                            writeCommentsAsTriplesToIssue(writer, githubIssueUri, ghIssue.listComments());
+                        }
+
                         issueCounter++;
 
                         if (issueCounter > 99) {
@@ -1165,6 +1169,31 @@ public class GithubRdfConversionTransactionService {
 
         for (GHUser reviewer : reviewers) {
             writer.triple(RdfGithubIssueUtils.createIssueReviewerProperty(issueUri, reviewer.getHtmlUrl().toString()));
+        }
+
+    }
+
+    private void writeCommentsAsTriplesToIssue(
+            StreamRDF writer,
+            String issueUri,
+            PagedIterable<GHIssueComment> comments) {
+
+        for (GHIssueComment comment : comments) {
+            String commentUri = comment.getHtmlUrl().toString();
+            writer.triple(RdfGithubIssueUtils.createIssueCommentProperty(issueUri, commentUri));
+            writer.triple(RdfGithubIssueUtils.createIssueCommentIdProperty(commentUri, comment.getId()));
+            if (comment.getUser() != null) {
+                writer.triple(RdfGithubIssueUtils.createIssueCommentUserProperty(commentUri, comment.getUser().getHtmlUrl().toString()));
+            }
+            if (comment.getBody() != null) {
+                writer.triple(RdfGithubIssueUtils.createIssueCommentBodyProperty(commentUri, comment.getBody()));
+            }
+            if (comment.getCreatedAt() != null) {
+                writer.triple(RdfGithubIssueUtils.createIssueCommentCreatedAtProperty(commentUri, localDateTimeFrom(comment.getCreatedAt())));
+            }
+            if (comment.getUpdatedAt() != null) {
+                writer.triple(RdfGithubIssueUtils.createIssueCommentUpdatedAtProperty(commentUri, localDateTimeFrom(comment.getUpdatedAt())));
+            }
         }
 
     }

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueUtils.java
@@ -78,6 +78,31 @@ public final class RdfGithubIssueUtils {
         return RdfUtils.uri(GH_NS + "issueMergedBy");
     }
 
+    // Comment related nodes
+    public static Node issueCommentProperty() {
+        return RdfUtils.uri(GH_NS + "issueComment");
+    }
+
+    public static Node issueCommentIdProperty() {
+        return RdfUtils.uri(GH_NS + "issueCommentId");
+    }
+
+    public static Node issueCommentBodyProperty() {
+        return RdfUtils.uri(GH_NS + "issueCommentBody");
+    }
+
+    public static Node issueCommentUserProperty() {
+        return RdfUtils.uri(GH_NS + "issueCommentUser");
+    }
+
+    public static Node issueCommentCreatedAtProperty() {
+        return RdfUtils.uri(GH_NS + "issueCommentCreatedAt");
+    }
+
+    public static Node issueCommentUpdatedAtProperty() {
+        return RdfUtils.uri(GH_NS + "issueCommentUpdatedAt");
+    }
+
 
     public static Triple createRdfTypeProperty(String issueUri) {
         return Triple.create(RdfUtils.uri(issueUri), rdfTypeProperty(), RdfUtils.uri( "github:GithubIssue" ));
@@ -138,6 +163,32 @@ public final class RdfGithubIssueUtils {
 
     public static Triple createIssueMergedByProperty(String issueUri, String userUri) {
         return Triple.create(RdfUtils.uri(issueUri), mergedByProperty(), RdfUtils.uri(userUri));
+    }
+
+    // Comment related triple creators
+
+    public static Triple createIssueCommentProperty(String issueUri, String commentUri) {
+        return Triple.create(RdfUtils.uri(issueUri), issueCommentProperty(), RdfUtils.uri(commentUri));
+    }
+
+    public static Triple createIssueCommentIdProperty(String commentUri, long id) {
+        return Triple.create(RdfUtils.uri(commentUri), issueCommentIdProperty(), RdfUtils.stringLiteral(Long.toString(id)));
+    }
+
+    public static Triple createIssueCommentBodyProperty(String commentUri, String body) {
+        return Triple.create(RdfUtils.uri(commentUri), issueCommentBodyProperty(), RdfUtils.stringLiteral(body));
+    }
+
+    public static Triple createIssueCommentUserProperty(String commentUri, String userUri) {
+        return Triple.create(RdfUtils.uri(commentUri), issueCommentUserProperty(), RdfUtils.uri(userUri));
+    }
+
+    public static Triple createIssueCommentCreatedAtProperty(String commentUri, LocalDateTime createdAt) {
+        return Triple.create(RdfUtils.uri(commentUri), issueCommentCreatedAtProperty(), RdfUtils.dateTimeLiteral(createdAt));
+    }
+
+    public static Triple createIssueCommentUpdatedAtProperty(String commentUri, LocalDateTime updatedAt) {
+        return Triple.create(RdfUtils.uri(commentUri), issueCommentUpdatedAtProperty(), RdfUtils.dateTimeLiteral(updatedAt));
     }
 
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,10 +22,11 @@ spring:
 
 worker:
   commits-per-iteration: 100
-  #issues:
-  #  pre-secondary-rate-limit-check: 800
-  #  seconds-to-sleep: 60
-  #  issue-page-size: 100
+  issues:
+    #pre-secondary-rate-limit-check: 800
+    #seconds-to-sleep: 60
+    #issue-page-size: 100
+    export-comments: true
   task:
     rdf-git-repo:
       enabled: ${WORKER_TASK_RDFGITREPO_ENABLED:true}


### PR DESCRIPTION
## Summary
- add issue comment nodes and triple creators
- include comment information during issue conversion
- support enabling comment export via application config

## Testing
- `./mvnw -q -DskipTests=true test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68582aec4724832bb954376fd40c91c2