### PR TITLE
Add detailed review RDF schema and extraction

### DIFF
--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueUtils.java
@@ -76,6 +76,35 @@ public final class RdfGithubIssueUtils {
         return RdfUtils.uri(GH_NS + "reviewer");
     }
 
+    // Review related nodes
+    public static Node reviewProperty() {
+        return RdfUtils.uri(GH_NS + "review");
+    }
+
+    public static Node reviewOfProperty() {
+        return RdfUtils.uri(GH_NS + "reviewOf");
+    }
+
+    public static Node reviewIdProperty() {
+        return RdfUtils.uri(GH_NS + "reviewId");
+    }
+
+    public static Node reviewBodyProperty() {
+        return RdfUtils.uri(GH_NS + "reviewBody");
+    }
+
+    public static Node reviewStateProperty() {
+        return RdfUtils.uri(GH_NS + "reviewState");
+    }
+
+    public static Node reviewUserProperty() {
+        return RdfUtils.uri(GH_NS + "reviewUser");
+    }
+
+    public static Node reviewSubmittedAtProperty() {
+        return RdfUtils.uri(GH_NS + "reviewSubmittedAt");
+    }
+
     public static Node mergedByProperty() {
         return RdfUtils.uri(GH_NS + "mergedBy");
     }
@@ -194,6 +223,39 @@ public final class RdfGithubIssueUtils {
 
     public static Triple createIssueReviewerProperty(String issueUri, String reviewerUri) {
         return Triple.create(RdfUtils.uri(issueUri), reviewerProperty(), RdfUtils.uri(reviewerUri));
+    }
+
+    // Review related triple creators
+    public static Triple createIssueReviewProperty(String issueUri, String reviewUri) {
+        return Triple.create(RdfUtils.uri(issueUri), reviewProperty(), RdfUtils.uri(reviewUri));
+    }
+
+    public static Triple createReviewRdfTypeProperty(String reviewUri) {
+        return Triple.create(RdfUtils.uri(reviewUri), rdfTypeProperty(), RdfUtils.uri("github:GithubReview"));
+    }
+
+    public static Triple createReviewOfProperty(String reviewUri, String issueUri) {
+        return Triple.create(RdfUtils.uri(reviewUri), reviewOfProperty(), RdfUtils.uri(issueUri));
+    }
+
+    public static Triple createReviewIdProperty(String reviewUri, long id) {
+        return Triple.create(RdfUtils.uri(reviewUri), reviewIdProperty(), RdfUtils.stringLiteral(Long.toString(id)));
+    }
+
+    public static Triple createReviewBodyProperty(String reviewUri, String body) {
+        return Triple.create(RdfUtils.uri(reviewUri), reviewBodyProperty(), RdfUtils.stringLiteral(body));
+    }
+
+    public static Triple createReviewStateProperty(String reviewUri, String state) {
+        return Triple.create(RdfUtils.uri(reviewUri), reviewStateProperty(), RdfUtils.uri(GH_NS + state.toLowerCase()));
+    }
+
+    public static Triple createReviewUserProperty(String reviewUri, String userUri) {
+        return Triple.create(RdfUtils.uri(reviewUri), reviewUserProperty(), RdfUtils.uri(userUri));
+    }
+
+    public static Triple createReviewSubmittedAtProperty(String reviewUri, LocalDateTime submittedAt) {
+        return Triple.create(RdfUtils.uri(reviewUri), reviewSubmittedAtProperty(), RdfUtils.dateTimeLiteral(submittedAt));
     }
 
     public static Triple createIssueMergedByProperty(String issueUri, String userUri) {


### PR DESCRIPTION
## Summary
- extend issue RDF utilities with review-related nodes and triple creators
- capture pull request review details when converting repos

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685954271a5c832b8851013b03a99e2b