### PR TITLE
Add detailed review RDF schema and extraction

### DIFF
--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
@@ -17,8 +17,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.commons.lang3.time.StopWatch;
 import org.apache.jena.graph.Node;
@@ -59,6 +61,7 @@ import org.kohsuke.github.GHIssueState;
 import org.kohsuke.github.GHLabel;
 import org.kohsuke.github.GHMilestone;
 import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHPullRequestReview;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GHUser;
 import org.kohsuke.github.GitHub;
@@ -783,6 +786,7 @@ public class GithubRdfConversionTransactionService {
 
                                 if (reviewersEnabled) {
                                     writeReviewersAsTripleToIssue(writer, githubIssueUri, pr.getRequestedReviewers());
+                                    writeReviewsAsTriplesToIssue(writer, githubIssueUri, pr.listReviews());
                                 }
 
                                 if (mergedByEnabled && pr.getMergedBy() != null) {
@@ -1204,6 +1208,50 @@ public class GithubRdfConversionTransactionService {
 
         for (GHUser reviewer : reviewers) {
             writer.triple(RdfGithubIssueUtils.createIssueReviewerProperty(issueUri, reviewer.getHtmlUrl().toString()));
+        }
+
+    }
+
+
+    private void writeReviewsAsTriplesToIssue(
+            StreamRDF writer,
+            String issueUri,
+            PagedIterable<GHPullRequestReview> reviews) throws IOException {
+
+        Set<Long> writtenIds = new HashSet<>();
+
+        for (GHPullRequestReview review : reviews) {
+            long reviewId = review.getId();
+            if (!writtenIds.add(reviewId)) {
+                // avoid duplicate entries for the same review
+                continue;
+            }
+
+            String reviewUri = issueUri + "#pullrequestreview-" + reviewId;
+
+            writer.triple(RdfGithubIssueUtils.createIssueReviewProperty(issueUri, reviewUri));
+            writer.triple(RdfGithubIssueUtils.createReviewRdfTypeProperty(reviewUri));
+            writer.triple(RdfGithubIssueUtils.createReviewOfProperty(reviewUri, issueUri));
+            writer.triple(RdfGithubIssueUtils.createReviewIdProperty(reviewUri, reviewId));
+
+            GHUser user = review.getUser();
+            if (user != null) {
+                writer.triple(RdfGithubIssueUtils.createReviewUserProperty(reviewUri, user.getHtmlUrl().toString()));
+            }
+
+            String body = review.getBody();
+            if (body != null) {
+                writer.triple(RdfGithubIssueUtils.createReviewBodyProperty(reviewUri, body));
+            }
+
+            if (review.getState() != null) {
+                writer.triple(RdfGithubIssueUtils.createReviewStateProperty(reviewUri, review.getState()));
+            }
+
+            if (review.getSubmittedAt() != null) {
+                LocalDateTime submitted = localDateTimeFrom(review.getSubmittedAt());
+                writer.triple(RdfGithubIssueUtils.createReviewSubmittedAtProperty(reviewUri, submitted));
+            }
         }
 
     }

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueUtils.java
@@ -76,6 +76,35 @@ public final class RdfGithubIssueUtils {
         return RdfUtils.uri(GH_NS + "reviewer");
     }
 
+    // Review related nodes
+    public static Node reviewProperty() {
+        return RdfUtils.uri(GH_NS + "review");
+    }
+
+    public static Node reviewOfProperty() {
+        return RdfUtils.uri(GH_NS + "reviewOf");
+    }
+
+    public static Node reviewIdProperty() {
+        return RdfUtils.uri(GH_NS + "reviewId");
+    }
+
+    public static Node reviewBodyProperty() {
+        return RdfUtils.uri(GH_NS + "reviewBody");
+    }
+
+    public static Node reviewStateProperty() {
+        return RdfUtils.uri(GH_NS + "reviewState");
+    }
+
+    public static Node reviewUserProperty() {
+        return RdfUtils.uri(GH_NS + "reviewUser");
+    }
+
+    public static Node reviewSubmittedAtProperty() {
+        return RdfUtils.uri(GH_NS + "reviewSubmittedAt");
+    }
+
     public static Node mergedByProperty() {
         return RdfUtils.uri(GH_NS + "mergedBy");
     }
@@ -194,6 +223,39 @@ public final class RdfGithubIssueUtils {
 
     public static Triple createIssueReviewerProperty(String issueUri, String reviewerUri) {
         return Triple.create(RdfUtils.uri(issueUri), reviewerProperty(), RdfUtils.uri(reviewerUri));
+    }
+
+    // Review related triple creators
+    public static Triple createIssueReviewProperty(String issueUri, String reviewUri) {
+        return Triple.create(RdfUtils.uri(issueUri), reviewProperty(), RdfUtils.uri(reviewUri));
+    }
+
+    public static Triple createReviewRdfTypeProperty(String reviewUri) {
+        return Triple.create(RdfUtils.uri(reviewUri), rdfTypeProperty(), RdfUtils.uri("github:GithubReview"));
+    }
+
+    public static Triple createReviewOfProperty(String reviewUri, String issueUri) {
+        return Triple.create(RdfUtils.uri(reviewUri), reviewOfProperty(), RdfUtils.uri(issueUri));
+    }
+
+    public static Triple createReviewIdProperty(String reviewUri, long id) {
+        return Triple.create(RdfUtils.uri(reviewUri), reviewIdProperty(), RdfUtils.stringLiteral(Long.toString(id)));
+    }
+
+    public static Triple createReviewBodyProperty(String reviewUri, String body) {
+        return Triple.create(RdfUtils.uri(reviewUri), reviewBodyProperty(), RdfUtils.stringLiteral(body));
+    }
+
+    public static Triple createReviewStateProperty(String reviewUri, String state) {
+        return Triple.create(RdfUtils.uri(reviewUri), reviewStateProperty(), RdfUtils.uri(GH_NS + state.toLowerCase()));
+    }
+
+    public static Triple createReviewUserProperty(String reviewUri, String userUri) {
+        return Triple.create(RdfUtils.uri(reviewUri), reviewUserProperty(), RdfUtils.uri(userUri));
+    }
+
+    public static Triple createReviewSubmittedAtProperty(String reviewUri, LocalDateTime submittedAt) {
+        return Triple.create(RdfUtils.uri(reviewUri), reviewSubmittedAtProperty(), RdfUtils.dateTimeLiteral(submittedAt));
     }
 
     public static Triple createIssueMergedByProperty(String issueUri, String userUri) {


### PR DESCRIPTION
## Summary
- extend issue RDF utilities with review-related nodes and triple creators
- capture pull request review details when converting repos
- deduplicate reviews and use stable URIs

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685954271a5c832b8851013b03a99e2b