### PR TITLE
Switch PR review URIs to path segments

### DIFF
--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
@@ -1202,7 +1202,7 @@ public class GithubRdfConversionTransactionService {
                 continue;
             }
 
-            String reviewUri = issueUri + "#pullrequestreview-" + reviewId;
+            String reviewUri = issueUri + "/reviews/" + reviewId;
 
             writer.triple(RdfGithubIssueUtils.createIssueReviewProperty(issueUri, reviewUri));
             writer.triple(RdfGithubIssueUtils.createReviewRdfTypeProperty(reviewUri));

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueUtils.java
@@ -238,7 +238,7 @@ public final class RdfGithubIssueUtils {
     }
 
     public static Triple createReviewIdProperty(String reviewUri, long id) {
-        return Triple.create(RdfUtils.uri(reviewUri), reviewIdProperty(), RdfUtils.stringLiteral(Long.toString(id)));
+        return Triple.create(RdfUtils.uri(reviewUri), reviewIdProperty(), RdfUtils.longLiteral(id));
     }
 
 


### PR DESCRIPTION
## Summary
- generate path-based URIs for PR reviews
- emit review IDs as typed longs

## Testing
- `sh mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685a9c6b7614832b97e26f6a58263930