### PR TITLE
Add issue comment id triple support

### DIFF
--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
@@ -1254,6 +1254,7 @@ public class GithubRdfConversionTransactionService {
             writer.triple(RdfGithubIssueUtils.createIssueCommentProperty(issueUri, commentUri));
             writer.triple(RdfGithubIssueUtils.createCommentRdfTypeProperty(commentUri));
             writer.triple(RdfGithubIssueUtils.createIssueCommentOfProperty(commentUri, issueUri));
+            writer.triple(RdfGithubIssueUtils.createIssueCommentIdProperty(commentUri, comment.getId()));
 
             GHUser user = comment.getUser();
             if (user != null) {

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueUtils.java
@@ -282,6 +282,11 @@ public final class RdfGithubIssueUtils {
         return Triple.create(RdfUtils.uri(issueUri), commentsProperty(), RdfUtils.uri(commentUri));
     }
 
+    public static Triple createIssueCommentIdProperty(String commentUri, long id) {
+        return Triple.create(RdfUtils.uri(commentUri), issueCommentIdProperty(),
+                RdfUtils.stringLiteral(Long.toString(id)));
+    }
+
     public static Triple createCommentRdfTypeProperty(String commentUri) {
         return Triple.create(RdfUtils.uri(commentUri), rdfTypeProperty(), RdfUtils.uri("github:GithubComment"));
     }


### PR DESCRIPTION
## Summary
- add `createIssueCommentIdProperty` to emit the id of an issue comment as RDF triple
- emit comment id triple in `writeCommentsAsTriplesToIssue`

## Testing
- `bash mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685a9c6c5b98832b807c6fd3d9fd82dd