### PR TITLE
Add RDF triples for PR review comments

### DIFF
--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
@@ -62,6 +62,7 @@ import org.kohsuke.github.GHLabel;
 import org.kohsuke.github.GHMilestone;
 import org.kohsuke.github.GHPullRequest;
 import org.kohsuke.github.GHPullRequestReview;
+import org.kohsuke.github.GHPullRequestReviewComment;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GHUser;
 import org.kohsuke.github.GitHub;
@@ -1240,6 +1241,44 @@ public class GithubRdfConversionTransactionService {
             if (review.getSubmittedAt() != null) {
                 LocalDateTime submitted = localDateTimeFrom(review.getSubmittedAt());
                 writer.triple(RdfGithubIssueUtils.createReviewSubmittedAtProperty(reviewUri, submitted));
+            }
+
+            // review comments
+            writeReviewCommentsAsTriples(writer, reviewUri, review.listReviewComments());
+        }
+
+    }
+
+    private void writeReviewCommentsAsTriples(
+            StreamRDF writer,
+            String reviewUri,
+            PagedIterable<GHPullRequestReviewComment> comments) throws IOException {
+
+        for (GHPullRequestReviewComment comment : comments) {
+            String commentUri = comment.getHtmlUrl().toString();
+            writer.triple(RdfGithubIssueUtils.createReviewCommentProperty(reviewUri, commentUri));
+            writer.triple(RdfGithubIssueUtils.createCommentRdfTypeProperty(commentUri));
+            writer.triple(RdfGithubIssueUtils.createReviewCommentOfProperty(commentUri, reviewUri));
+
+            GHUser user = comment.getUser();
+            if (user != null) {
+                writer.triple(RdfGithubIssueUtils.createReviewCommentUserProperty(
+                        commentUri, user.getHtmlUrl().toString()));
+            }
+
+            String body = comment.getBody();
+            if (body != null) {
+                writer.triple(RdfGithubIssueUtils.createReviewCommentBodyProperty(commentUri, body));
+            }
+
+            if (comment.getCreatedAt() != null) {
+                LocalDateTime created = localDateTimeFrom(comment.getCreatedAt());
+                writer.triple(RdfGithubIssueUtils.createReviewCommentCreatedAtProperty(commentUri, created));
+            }
+
+            if (comment.getUpdatedAt() != null) {
+                LocalDateTime updated = localDateTimeFrom(comment.getUpdatedAt());
+                writer.triple(RdfGithubIssueUtils.createReviewCommentUpdatedAtProperty(commentUri, updated));
             }
         }
 

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueUtils.java
@@ -170,6 +170,31 @@ public final class RdfGithubIssueUtils {
         return RdfUtils.uri(GH_NS + "issueCommentUpdatedAt");
     }
 
+    // Review comment related nodes
+    public static Node reviewCommentProperty() {
+        return RdfUtils.uri(GH_NS + "reviewComment");
+    }
+
+    public static Node reviewCommentOfProperty() {
+        return RdfUtils.uri(GH_NS + "reviewCommentOf");
+    }
+
+    public static Node reviewCommentBodyProperty() {
+        return RdfUtils.uri(GH_NS + "reviewCommentBody");
+    }
+
+    public static Node reviewCommentUserProperty() {
+        return RdfUtils.uri(GH_NS + "reviewCommentUser");
+    }
+
+    public static Node reviewCommentCreatedAtProperty() {
+        return RdfUtils.uri(GH_NS + "reviewCommentCreatedAt");
+    }
+
+    public static Node reviewCommentUpdatedAtProperty() {
+        return RdfUtils.uri(GH_NS + "reviewCommentUpdatedAt");
+    }
+
 
     public static Triple createRdfTypeProperty(String issueUri) {
         return Triple.create(RdfUtils.uri(issueUri), rdfTypeProperty(), RdfUtils.uri("github:GithubIssue"));
@@ -305,6 +330,31 @@ public final class RdfGithubIssueUtils {
     public static Triple createIssueCommentUpdatedAtProperty(String commentUri, LocalDateTime updatedAt) {
         return Triple.create(RdfUtils.uri(commentUri), commentUpdatedAtProperty(), RdfUtils.dateTimeLiteral(updatedAt));
 
+    }
+
+    // Review comment related triple creators
+    public static Triple createReviewCommentProperty(String reviewUri, String commentUri) {
+        return Triple.create(RdfUtils.uri(reviewUri), reviewCommentProperty(), RdfUtils.uri(commentUri));
+    }
+
+    public static Triple createReviewCommentOfProperty(String commentUri, String reviewUri) {
+        return Triple.create(RdfUtils.uri(commentUri), reviewCommentOfProperty(), RdfUtils.uri(reviewUri));
+    }
+
+    public static Triple createReviewCommentBodyProperty(String commentUri, String body) {
+        return Triple.create(RdfUtils.uri(commentUri), reviewCommentBodyProperty(), RdfUtils.stringLiteral(body));
+    }
+
+    public static Triple createReviewCommentUserProperty(String commentUri, String userUri) {
+        return Triple.create(RdfUtils.uri(commentUri), reviewCommentUserProperty(), RdfUtils.uri(userUri));
+    }
+
+    public static Triple createReviewCommentCreatedAtProperty(String commentUri, LocalDateTime createdAt) {
+        return Triple.create(RdfUtils.uri(commentUri), reviewCommentCreatedAtProperty(), RdfUtils.dateTimeLiteral(createdAt));
+    }
+
+    public static Triple createReviewCommentUpdatedAtProperty(String commentUri, LocalDateTime updatedAt) {
+        return Triple.create(RdfUtils.uri(commentUri), reviewCommentUpdatedAtProperty(), RdfUtils.dateTimeLiteral(updatedAt));
     }
 
 }


### PR DESCRIPTION
## Summary
- generate RDF triples for pull request review comments
- provide utility functions for review comment properties and triple creation

## Testing
- `sh mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685a9c6dca2c832b9ecbbb7f55e29f55