### PR TITLE
Represent PR reviews as RDF bags

### DIFF
--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
@@ -1195,7 +1195,11 @@ public class GithubRdfConversionTransactionService {
             String issueUri,
             PagedIterable<GHPullRequestReview> reviews) throws IOException {
 
+        String collectionUri = issueUri + "#reviews";
+        writer.triple(RdfGithubIssueUtils.createIssueReviewsProperty(issueUri, collectionUri));
+        writer.triple(RdfGithubIssueUtils.createReviewsCollectionTypeBag(collectionUri));
 
+        int index = 1;
         for (GHPullRequestReview review : reviews) {
             long reviewId = review.getId();
             if (!seenReviewIds.add(reviewId)) {
@@ -1205,8 +1209,7 @@ public class GithubRdfConversionTransactionService {
             }
 
             String reviewUri = issueUri + "/reviews/" + reviewId;
-
-            writer.triple(RdfGithubIssueUtils.createIssueReviewProperty(issueUri, reviewUri));
+            writer.triple(RdfGithubIssueUtils.createReviewsCollectionMemberProperty(collectionUri, index++, reviewUri));
             writer.triple(RdfGithubIssueUtils.createReviewRdfTypeProperty(reviewUri));
             writer.triple(RdfGithubIssueUtils.createReviewOfProperty(reviewUri, issueUri));
             writer.triple(RdfGithubIssueUtils.createReviewIdProperty(reviewUri, reviewId));

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueUtils.java
@@ -75,6 +75,7 @@ public final class RdfGithubIssueUtils {
     }
 
     // Review related nodes
+    public static Node reviewsProperty() { return RdfUtils.uri(GH_NS + "reviews"); }
     public static Node reviewProperty() {
         return RdfUtils.uri(GH_NS + "review");
     }
@@ -271,6 +272,19 @@ public final class RdfGithubIssueUtils {
     }
 
     // Review related triple creators
+    public static Triple createIssueReviewsProperty(String issueUri, String collectionUri) {
+        return Triple.create(RdfUtils.uri(issueUri), reviewsProperty(), RdfUtils.uri(collectionUri));
+    }
+
+    public static Triple createReviewsCollectionTypeBag(String collectionUri) {
+        return Triple.create(RdfUtils.uri(collectionUri), rdfTypeProperty(), RdfUtils.uri("rdf:Bag"));
+    }
+
+    public static Triple createReviewsCollectionMemberProperty(String collectionUri, int index, String reviewUri) {
+        return Triple.create(RdfUtils.uri(collectionUri), RdfUtils.uri("rdf:_" + index), RdfUtils.uri(reviewUri));
+    }
+
+    // kept for direct links if required
     public static Triple createIssueReviewProperty(String issueUri, String reviewUri) {
         return Triple.create(RdfUtils.uri(issueUri), reviewProperty(), RdfUtils.uri(reviewUri));
     }


### PR DESCRIPTION
## Summary
- add `reviewsProperty` and helper triple builders for review collections
- list PR reviews via `github:reviews` bag instead of individual `github:review` links

## Testing
- `./mvnw -q -DskipTests install` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685ab36a1548832ba5bb0ca3451c4ab6