### PR TITLE
Support discussion containers for issue and review comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ See the folder `target` for the executable JAR file.
 | `GITHUB_LOGIN_SYSTEM_USER_NAME`                | Your GitHub login username. Is used in combination with your personal access token to pull Git repositories from GitHub.                                                                                                                                                                                                                           |
 | `GITHUB_LOGIN_SYSTEM_USER_PERSONALACCESSTOKEN` | A personal access token for your GitHub user. Is used in combination with your username to pull Git repositories from GitHub.                                                                                                                                                                                                                      |
 
+## Discussion containers
+
+Issues and reviews expose their comments via a dedicated container located at `#comments` relative to the parent resource. The parent links to this container via `github:discussion`. The container is typed as `rdf:Bag` and enumerates comment URIs using ordinal properties like `rdf:_1`, `rdf:_2`.
+
 [Spring Initializr Template](https://start.spring.io/#!type=maven-project&language=java&platformVersion=3.2.2&packaging=jar&jvmVersion=21&groupId=de.leipzig.htwk.gitrdf&artifactId=worker&name=worker&description=Archetype%20project%20for%20HTWK%20Leipzig%20-%20Project%20to%20transform%20git%20to%20RDF&packageName=de.leipzig.htwk.gitrdf.worker&dependencies=lombok,devtools,data-jpa,postgresql,testcontainers,integration)
 
 [New Spring Initializr Template](https://start.spring.io/#!type=maven-project&language=java&platformVersion=3.2.2&packaging=jar&jvmVersion=21&groupId=de.leipzig.htwk.gitrdf&artifactId=worker&name=worker&description=Archetype%20project%20for%20HTWK%20Leipzig%20-%20Project%20to%20transform%20git%20to%20RDF&packageName=de.leipzig.htwk.gitrdf.worker&dependencies=lombok,devtools,data-jpa,postgresql,testcontainers,integration,flyway)

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
@@ -29,6 +29,8 @@ import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.riot.RDFFormat;
 import org.apache.jena.riot.system.StreamRDF;
 import org.apache.jena.riot.system.StreamRDFWriter;
+import org.apache.jena.graph.Triple;
+import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfUtils;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.ListBranchCommand;
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -1255,8 +1257,15 @@ public class GithubRdfConversionTransactionService {
             String reviewUri,
             PagedIterable<GHPullRequestReviewComment> comments) throws IOException {
 
+        String containerUri = reviewUri + "#comments";
+        writer.triple(RdfGithubIssueUtils.createReviewDiscussionProperty(reviewUri, containerUri));
+        writer.triple(RdfGithubIssueUtils.createDiscussionOfProperty(containerUri, reviewUri));
+        writer.triple(RdfGithubIssueUtils.createDiscussionRdfTypeBag(containerUri));
+
+        int index = 1;
         for (GHPullRequestReviewComment comment : comments) {
             String commentUri = comment.getHtmlUrl().toString();
+            writer.triple(Triple.create(RdfUtils.uri(containerUri), RdfGithubIssueUtils.bagItemProperty(index++), RdfUtils.uri(commentUri)));
             writer.triple(RdfGithubIssueUtils.createReviewCommentProperty(reviewUri, commentUri));
             writer.triple(RdfGithubIssueUtils.createCommentRdfTypeProperty(commentUri));
             writer.triple(RdfGithubIssueUtils.createReviewCommentOfProperty(commentUri, reviewUri));
@@ -1289,8 +1298,16 @@ public class GithubRdfConversionTransactionService {
             String issueUri,
             PagedIterable<GHIssueComment> comments)
             throws IOException { // <-- propagate
+
+        String containerUri = issueUri + "#comments";
+        writer.triple(RdfGithubIssueUtils.createIssueDiscussionProperty(issueUri, containerUri));
+        writer.triple(RdfGithubIssueUtils.createDiscussionOfProperty(containerUri, issueUri));
+        writer.triple(RdfGithubIssueUtils.createDiscussionRdfTypeBag(containerUri));
+
+        int index = 1;
         for (GHIssueComment comment : comments) {
             String commentUri = comment.getHtmlUrl().toString();
+            writer.triple(Triple.create(RdfUtils.uri(containerUri), RdfGithubIssueUtils.bagItemProperty(index++), RdfUtils.uri(commentUri)));
             writer.triple(RdfGithubIssueUtils.createIssueCommentProperty(issueUri, commentUri));
             writer.triple(RdfGithubIssueUtils.createCommentRdfTypeProperty(commentUri));
             writer.triple(RdfGithubIssueUtils.createIssueCommentOfProperty(commentUri, issueUri));

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueUtils.java
@@ -150,6 +150,15 @@ public final class RdfGithubIssueUtils {
     public static Node commentOfProperty() {
         return RdfUtils.uri(GH_NS + "commentOf");
     }
+
+    // Discussion container related nodes
+    public static Node discussionProperty() {
+        return RdfUtils.uri(GH_NS + "discussion");
+    }
+
+    public static Node discussionOfProperty() {
+        return RdfUtils.uri(GH_NS + "discussionOf");
+    }
     public static Node commentBodyProperty() {
         return bodyProperty();
     }
@@ -215,6 +224,11 @@ public final class RdfGithubIssueUtils {
     public static Node reviewCommentUpdatedAtProperty() {
         return RdfUtils.uri(GH_NS + "reviewCommentUpdatedAt");
     }
+
+    public static Node bagItemProperty(int index) {
+        return RdfUtils.uri("rdf:_" + index);
+    }
+
 
 
     public static Triple createRdfTypeProperty(String issueUri) {
@@ -392,6 +406,23 @@ public final class RdfGithubIssueUtils {
 
     public static Triple createReviewCommentUpdatedAtProperty(String commentUri, LocalDateTime updatedAt) {
         return Triple.create(RdfUtils.uri(commentUri), reviewCommentUpdatedAtProperty(), RdfUtils.dateTimeLiteral(updatedAt));
+    }
+
+    // Discussion container triple creators
+    public static Triple createIssueDiscussionProperty(String issueUri, String containerUri) {
+        return Triple.create(RdfUtils.uri(issueUri), discussionProperty(), RdfUtils.uri(containerUri));
+    }
+
+    public static Triple createReviewDiscussionProperty(String reviewUri, String containerUri) {
+        return Triple.create(RdfUtils.uri(reviewUri), discussionProperty(), RdfUtils.uri(containerUri));
+    }
+
+    public static Triple createDiscussionOfProperty(String containerUri, String parentUri) {
+        return Triple.create(RdfUtils.uri(containerUri), discussionOfProperty(), RdfUtils.uri(parentUri));
+    }
+
+    public static Triple createDiscussionRdfTypeBag(String containerUri) {
+        return Triple.create(RdfUtils.uri(containerUri), rdfTypeProperty(), RdfUtils.uri("rdf:Bag"));
     }
 
 }


### PR DESCRIPTION
## Summary
- add new RDF nodes and triple creators for comment discussion containers
- mark each issue and review with a `github:discussion` container typed as `rdf:Bag`
- link container memberships when writing issue or review comments
- document the discussion container structure in README

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685ab36c410c832b848419c83a9e717c