### PR TITLE
Implement review containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ See the folder `target` for the executable JAR file.
 [New Spring Initializr Template](https://start.spring.io/#!type=maven-project&language=java&platformVersion=3.2.2&packaging=jar&jvmVersion=21&groupId=de.leipzig.htwk.gitrdf&artifactId=worker&name=worker&description=Archetype%20project%20for%20HTWK%20Leipzig%20-%20Project%20to%20transform%20git%20to%20RDF&packageName=de.leipzig.htwk.gitrdf.worker&dependencies=lombok,devtools,data-jpa,postgresql,testcontainers,integration,flyway)
 
 
+## Review Container Example
+
+Pull request reviews are now grouped inside a dedicated container.
+
+```turtle
+<#pr123> github:reviews <#pr123/reviews> .
+
+<#pr123/reviews> a github:ReviewContainer, rdf:Bag ;
+    rdf:_1 <#pr123/reviews/1> ;
+    rdf:_2 <#pr123/reviews/2> .
+```
+
+
 ## Contribute
 
 We are happy to receive your contributions. 

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
@@ -1196,6 +1196,12 @@ public class GithubRdfConversionTransactionService {
             PagedIterable<GHPullRequestReview> reviews) throws IOException {
 
 
+        String reviewsUri = issueUri + "/reviews";
+        writer.triple(RdfGithubIssueUtils.createIssueReviewsProperty(issueUri, reviewsUri));
+        writer.triple(RdfGithubIssueUtils.createReviewContainerTypeProperty(reviewsUri));
+        writer.triple(Triple.create(RdfUtils.uri(reviewsUri), RdfGithubIssueUtils.rdfTypeProperty(), RdfUtils.uri("rdf:Bag")));
+
+        int index = 1;
         for (GHPullRequestReview review : reviews) {
             long reviewId = review.getId();
             if (!seenReviewIds.add(reviewId)) {
@@ -1204,9 +1210,9 @@ public class GithubRdfConversionTransactionService {
                 continue;
             }
 
-            String reviewUri = issueUri + "/reviews/" + reviewId;
+            String reviewUri = reviewsUri + "/" + reviewId;
 
-            writer.triple(RdfGithubIssueUtils.createIssueReviewProperty(issueUri, reviewUri));
+            writer.triple(Triple.create(RdfUtils.uri(reviewsUri), RdfUtils.uri("rdf:_" + index++), RdfUtils.uri(reviewUri)));
             writer.triple(RdfGithubIssueUtils.createReviewRdfTypeProperty(reviewUri));
             writer.triple(RdfGithubIssueUtils.createReviewOfProperty(reviewUri, issueUri));
             writer.triple(RdfGithubIssueUtils.createReviewIdProperty(reviewUri, reviewId));

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueUtils.java
@@ -142,6 +142,10 @@ public final class RdfGithubIssueUtils {
         return RdfUtils.uri(GH_NS + "repository");
     }
 
+    // Review container related nodes
+    public static Node reviewsProperty() { return RdfUtils.uri(GH_NS + "reviews"); }
+    public static Node reviewContainerType() { return RdfUtils.uri(GH_NS + "ReviewContainer"); }
+
     // Comment related nodes
     public static Node commentsProperty() {
         return RdfUtils.uri(GH_NS + "comments");
@@ -392,6 +396,15 @@ public final class RdfGithubIssueUtils {
 
     public static Triple createReviewCommentUpdatedAtProperty(String commentUri, LocalDateTime updatedAt) {
         return Triple.create(RdfUtils.uri(commentUri), reviewCommentUpdatedAtProperty(), RdfUtils.dateTimeLiteral(updatedAt));
+    }
+
+    // Review container triple creators
+    public static Triple createIssueReviewsProperty(String issueUri, String containerUri) {
+        return Triple.create(RdfUtils.uri(issueUri), reviewsProperty(), RdfUtils.uri(containerUri));
+    }
+
+    public static Triple createReviewContainerTypeProperty(String containerUri) {
+        return Triple.create(RdfUtils.uri(containerUri), rdfTypeProperty(), reviewContainerType());
     }
 
 }

--- a/src/test/java/de/leipzig/htwk/gitrdf/worker/RdfReviewContainerTest.java
+++ b/src/test/java/de/leipzig/htwk/gitrdf/worker/RdfReviewContainerTest.java
@@ -1,0 +1,37 @@
+package de.leipzig.htwk.gitrdf.worker;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.jena.graph.Factory;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.Triple;
+import org.junit.jupiter.api.Test;
+
+import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGithubIssueUtils;
+import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfUtils;
+
+public class RdfReviewContainerTest {
+
+    @Test
+    void reviewsAreContainedInBag() {
+        Graph graph = Factory.createDefaultGraph();
+
+        String issueUri = "https://example.com/pull/1";
+        String reviewsUri = issueUri + "/reviews";
+        String review1 = reviewsUri + "/10";
+        String review2 = reviewsUri + "/20";
+
+        graph.add(RdfGithubIssueUtils.createIssueReviewsProperty(issueUri, reviewsUri));
+        graph.add(RdfGithubIssueUtils.createReviewContainerTypeProperty(reviewsUri));
+        graph.add(Triple.create(RdfUtils.uri(reviewsUri), RdfGithubIssueUtils.rdfTypeProperty(), RdfUtils.uri("rdf:Bag")));
+        graph.add(Triple.create(RdfUtils.uri(reviewsUri), RdfUtils.uri("rdf:_1"), RdfUtils.uri(review1)));
+        graph.add(Triple.create(RdfUtils.uri(reviewsUri), RdfUtils.uri("rdf:_2"), RdfUtils.uri(review2)));
+
+        assertEquals(1, graph.find(RdfUtils.uri(issueUri), RdfGithubIssueUtils.reviewsProperty(), Node.ANY).toList().size());
+        assertTrue(graph.contains(RdfUtils.uri(reviewsUri), RdfUtils.uri("rdf:_1"), RdfUtils.uri(review1)));
+        assertTrue(graph.contains(RdfUtils.uri(reviewsUri), RdfUtils.uri("rdf:_2"), RdfUtils.uri(review2)));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add new RDF nodes for GitHub review containers
- emit review container triples linking pull requests to `rdf:Bag`
- update README with new turtle example
- unit test for review container structure

## Testing
- `sh mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685ab3a5dc98832bb63767ac4f69414d