### PR TITLE
Remove issue comments from RDF output

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See the folder `target` for the executable JAR file.
 
 ## Discussion containers
 
-Issues and reviews expose their comments via a dedicated container located at `#comments` relative to the parent resource. The parent links to this container via `github:discussion`. The container is typed as `rdf:Bag` and enumerates comment URIs using ordinal properties like `rdf:_1`, `rdf:_2`.
+Reviews expose their comments via a dedicated container located at `#comments` relative to the parent resource. The parent links to this container via `github:discussion`. The container is typed as `rdf:Bag` and enumerates comment URIs using ordinal properties like `rdf:_1`, `rdf:_2`.
 
 [Spring Initializr Template](https://start.spring.io/#!type=maven-project&language=java&platformVersion=3.2.2&packaging=jar&jvmVersion=21&groupId=de.leipzig.htwk.gitrdf&artifactId=worker&name=worker&description=Archetype%20project%20for%20HTWK%20Leipzig%20-%20Project%20to%20transform%20git%20to%20RDF&packageName=de.leipzig.htwk.gitrdf.worker&dependencies=lombok,devtools,data-jpa,postgresql,testcontainers,integration)
 

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
@@ -855,7 +855,8 @@ public class GithubRdfConversionTransactionService {
                         }
 
                         if (githubIssueRepositoryFilter.isEnableIssueComments()) {
-                            writeCommentsAsTriplesToIssue(writer, githubIssueUri, ghIssue.listComments());
+                            // Issue comments are intentionally ignored. Conversation
+                            // metadata for issues is no longer written.
                         }
 
                         issueCounter++;
@@ -1314,57 +1315,8 @@ public class GithubRdfConversionTransactionService {
     private void writeCommentsAsTriplesToIssue(StreamRDF writer,
             String issueUri,
             PagedIterable<GHIssueComment> comments)
-            throws IOException { // <-- propagate
-
-        String conversationUri = issueUri + "#conversation";
-        writer.triple(RdfGithubIssueUtils.createHasConversationProperty(issueUri, conversationUri));
-        writer.triple(RdfGithubIssueUtils.createConversationOfProperty(conversationUri, issueUri));
-        writer.triple(RdfGithubIssueUtils.createConversationRdfType(conversationUri));
-
-        int index = 0;
-        String first = null;
-        String previous = null;
-        for (GHIssueComment comment : comments) {
-            String commentUri = comment.getHtmlUrl().toString();
-            index++;
-            if (first == null) first = commentUri;
-            if (previous != null) {
-                writer.triple(RdfGithubIssueUtils.createNextCommentProperty(previous, commentUri));
-                writer.triple(RdfGithubIssueUtils.createPreviousCommentProperty(commentUri, previous));
-            }
-            writer.triple(RdfGithubIssueUtils.createPartOfConversationProperty(commentUri, conversationUri));
-            writer.triple(RdfGithubIssueUtils.createIssueCommentProperty(issueUri, commentUri));
-            writer.triple(RdfGithubIssueUtils.createCommentRdfTypeProperty(commentUri));
-            writer.triple(RdfGithubIssueUtils.createIssueCommentOfProperty(commentUri, issueUri));
-            writer.triple(RdfGithubIssueUtils.createIssueCommentIdProperty(commentUri, comment.getId()));
-
-            GHUser user = comment.getUser();
-            if (user != null) {
-                writer.triple(RdfGithubIssueUtils.createIssueCommentUserProperty(
-                        commentUri, user.getHtmlUrl().toString()));
-            }
-
-            String body = comment.getBody();
-            if (body != null) {
-                writer.triple(RdfGithubIssueUtils.createIssueCommentBodyProperty(commentUri, body));
-            }
-
-            if (comment.getCreatedAt() != null) {
-                LocalDateTime created = localDateTimeFrom(comment.getCreatedAt());
-                writer.triple(RdfGithubIssueUtils.createIssueCommentCreatedAtProperty(commentUri, created));
-            }
-
-            if (comment.getUpdatedAt() != null) {
-                LocalDateTime updated = localDateTimeFrom(comment.getUpdatedAt());
-                writer.triple(RdfGithubIssueUtils.createIssueCommentUpdatedAtProperty(commentUri, updated));
-            }
-            previous = commentUri;
-        }
-        writer.triple(RdfGithubIssueUtils.createCommentCountProperty(conversationUri, index));
-        if (first != null) {
-            writer.triple(RdfGithubIssueUtils.createFirstCommentProperty(conversationUri, first));
-            writer.triple(RdfGithubIssueUtils.createLastCommentProperty(conversationUri, previous));
-        }
+            throws IOException {
+        // Issue comments are no longer exported to RDF.
     }
 
     private int calculateSkipCountAndThrowExceptionIfIntegerOverflowIsImminent(


### PR DESCRIPTION
## Summary
- drop issue comment mentions from README
- stop writing issue comment and conversation triples

## Testing
- `sh mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685fa30c18cc832b8c6109663848f91f