### PR TITLE
Add issue review/comment utilities

### DIFF
--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueUtils.java
@@ -69,6 +69,73 @@ public final class RdfGithubIssueUtils {
         return RdfUtils.uri(GH_NS + "repository");
     }
 
+    // Merge information
+    public static Node mergedProperty() { return RdfUtils.uri(GH_NS + "merged"); }
+
+    public static Node mergedAtProperty() { return RdfUtils.uri(GH_NS + "mergedAt"); }
+
+    public static Node mergedByProperty() { return RdfUtils.uri(GH_NS + "mergedBy"); }
+
+    public static Node mergeCommitShaProperty() { return RdfUtils.uri(GH_NS + "mergeCommitSha"); }
+
+    public static Node squashedProperty() { return RdfUtils.uri(GH_NS + "squashed"); }
+
+    public static Node rebasedProperty() { return RdfUtils.uri(GH_NS + "rebased"); }
+
+    // Review linkage
+    public static Node hasReviewProperty() { return RdfUtils.uri(GH_NS + "hasReview"); }
+
+    public static Node reviewCountProperty() { return RdfUtils.uri(GH_NS + "reviewCount"); }
+
+    public static Node reviewContainerProperty() { return RdfUtils.uri(GH_NS + "reviewContainer"); }
+
+    // Review details
+    public static Node reviewOfProperty() { return RdfUtils.uri(GH_NS + "reviewOf"); }
+
+    public static Node reviewIdentifierProperty() { return RdfUtils.uri(GH_NS + "reviewIdentifier"); }
+
+    public static Node reviewStateProperty() { return RdfUtils.uri(GH_NS + "reviewState"); }
+
+    public static Node reviewAuthorProperty() { return RdfUtils.uri(GH_NS + "reviewAuthor"); }
+
+    public static Node reviewCreatedAtProperty() { return RdfUtils.uri(GH_NS + "reviewCreatedAt"); }
+
+    public static Node reviewUpdatedAtProperty() { return RdfUtils.uri(GH_NS + "reviewUpdatedAt"); }
+
+    public static Node reviewCommitIdProperty() { return RdfUtils.uri(GH_NS + "reviewCommitId"); }
+
+    public static Node authorAssociationProperty() { return RdfUtils.uri(GH_NS + "authorAssociation"); }
+
+    public static Node reviewCommentCountProperty() { return RdfUtils.uri(GH_NS + "reviewCommentCount"); }
+
+    public static Node hasReviewCommentProperty() { return RdfUtils.uri(GH_NS + "hasReviewComment"); }
+
+    // Comment linkage
+    public static Node hasCommentProperty() { return RdfUtils.uri(GH_NS + "hasComment"); }
+
+    public static Node commentCountProperty() { return RdfUtils.uri(GH_NS + "commentCount"); }
+
+    public static Node discussionProperty() { return RdfUtils.uri(GH_NS + "discussion"); }
+
+    // Comment details
+    public static Node commentOfProperty() { return RdfUtils.uri(GH_NS + "commentOf"); }
+
+    public static Node commentIdentifierProperty() { return RdfUtils.uri(GH_NS + "commentIdentifier"); }
+
+    public static Node commentDescriptionProperty() { return RdfUtils.uri(GH_NS + "commentDescription"); }
+
+    public static Node commentCreatedAtProperty() { return RdfUtils.uri(GH_NS + "commentCreatedAt"); }
+
+    public static Node commentAuthorProperty() { return RdfUtils.uri(GH_NS + "commentAuthor"); }
+
+    public static Node isRootCommentProperty() { return RdfUtils.uri(GH_NS + "isRootComment"); }
+
+    public static Node commentReplyCountProperty() { return RdfUtils.uri(GH_NS + "commentReplyCount"); }
+
+    public static Node hasCommentReplyProperty() { return RdfUtils.uri(GH_NS + "hasCommentReply"); }
+
+    public static Node commentReplyToProperty() { return RdfUtils.uri(GH_NS + "commentReplyTo"); }
+
 
 
 
@@ -126,6 +193,135 @@ public final class RdfGithubIssueUtils {
 
     public static Triple createIssueRepositoryProperty(String issueUri, String repoUri) {
         return Triple.create(RdfUtils.uri(issueUri), repositoryProperty(), RdfUtils.uri(repoUri));
+    }
+
+    // Merge information triples
+    public static Triple createIssueMergedProperty(String issueUri, boolean merged) {
+        return Triple.create(RdfUtils.uri(issueUri), mergedProperty(), RdfUtils.stringLiteral(Boolean.toString(merged)));
+    }
+
+    public static Triple createIssueMergedAtProperty(String issueUri, LocalDateTime mergedAtDateTime) {
+        return Triple.create(RdfUtils.uri(issueUri), mergedAtProperty(), RdfUtils.dateTimeLiteral(mergedAtDateTime));
+    }
+
+    public static Triple createIssueMergedByProperty(String issueUri, String userUri) {
+        return Triple.create(RdfUtils.uri(issueUri), mergedByProperty(), RdfUtils.uri(userUri));
+    }
+
+    public static Triple createIssueMergeCommitShaProperty(String issueUri, String sha) {
+        return Triple.create(RdfUtils.uri(issueUri), mergeCommitShaProperty(), RdfUtils.stringLiteral(sha));
+    }
+
+    public static Triple createIssueSquashedProperty(String issueUri, boolean squashed) {
+        return Triple.create(RdfUtils.uri(issueUri), squashedProperty(), RdfUtils.stringLiteral(Boolean.toString(squashed)));
+    }
+
+    public static Triple createIssueRebasedProperty(String issueUri, boolean rebased) {
+        return Triple.create(RdfUtils.uri(issueUri), rebasedProperty(), RdfUtils.stringLiteral(Boolean.toString(rebased)));
+    }
+
+    // Review linkage triples
+    public static Triple createIssueHasReviewProperty(String issueUri, String reviewUri) {
+        return Triple.create(RdfUtils.uri(issueUri), hasReviewProperty(), RdfUtils.uri(reviewUri));
+    }
+
+    public static Triple createIssueReviewCountProperty(String issueUri, long count) {
+        return Triple.create(RdfUtils.uri(issueUri), reviewCountProperty(), RdfUtils.nonNegativeIntegerLiteral(count));
+    }
+
+    public static Triple createIssueReviewContainerProperty(String issueUri, String containerUri) {
+        return Triple.create(RdfUtils.uri(issueUri), reviewContainerProperty(), RdfUtils.uri(containerUri));
+    }
+
+    // Review detail triples
+    public static Triple createReviewOfProperty(String reviewUri, String issueUri) {
+        return Triple.create(RdfUtils.uri(reviewUri), reviewOfProperty(), RdfUtils.uri(issueUri));
+    }
+
+    public static Triple createReviewIdentifierProperty(String reviewUri, long identifier) {
+        return Triple.create(RdfUtils.uri(reviewUri), reviewIdentifierProperty(), RdfUtils.stringLiteral(Long.toString(identifier)));
+    }
+
+    public static Triple createReviewStateProperty(String reviewUri, String state) {
+        return Triple.create(RdfUtils.uri(reviewUri), reviewStateProperty(), uri(state.toLowerCase()));
+    }
+
+    public static Triple createReviewAuthorProperty(String reviewUri, String userUri) {
+        return Triple.create(RdfUtils.uri(reviewUri), reviewAuthorProperty(), RdfUtils.uri(userUri));
+    }
+
+    public static Triple createReviewCreatedAtProperty(String reviewUri, LocalDateTime createdAt) {
+        return Triple.create(RdfUtils.uri(reviewUri), reviewCreatedAtProperty(), RdfUtils.dateTimeLiteral(createdAt));
+    }
+
+    public static Triple createReviewUpdatedAtProperty(String reviewUri, LocalDateTime updatedAt) {
+        return Triple.create(RdfUtils.uri(reviewUri), reviewUpdatedAtProperty(), RdfUtils.dateTimeLiteral(updatedAt));
+    }
+
+    public static Triple createReviewCommitIdProperty(String reviewUri, String commitId) {
+        return Triple.create(RdfUtils.uri(reviewUri), reviewCommitIdProperty(), RdfUtils.stringLiteral(commitId));
+    }
+
+    public static Triple createReviewAuthorAssociationProperty(String reviewUri, String association) {
+        return Triple.create(RdfUtils.uri(reviewUri), authorAssociationProperty(), RdfUtils.stringLiteral(association));
+    }
+
+    public static Triple createReviewCommentCountProperty(String reviewUri, long count) {
+        return Triple.create(RdfUtils.uri(reviewUri), reviewCommentCountProperty(), RdfUtils.nonNegativeIntegerLiteral(count));
+    }
+
+    public static Triple createReviewHasCommentProperty(String reviewUri, String commentUri) {
+        return Triple.create(RdfUtils.uri(reviewUri), hasReviewCommentProperty(), RdfUtils.uri(commentUri));
+    }
+
+    // Comment linkage triples
+    public static Triple createIssueHasCommentProperty(String issueUri, String commentUri) {
+        return Triple.create(RdfUtils.uri(issueUri), hasCommentProperty(), RdfUtils.uri(commentUri));
+    }
+
+    public static Triple createIssueCommentCountProperty(String issueUri, long count) {
+        return Triple.create(RdfUtils.uri(issueUri), commentCountProperty(), RdfUtils.nonNegativeIntegerLiteral(count));
+    }
+
+    public static Triple createIssueDiscussionProperty(String issueUri, String discussionUri) {
+        return Triple.create(RdfUtils.uri(issueUri), discussionProperty(), RdfUtils.uri(discussionUri));
+    }
+
+    // Comment detail triples
+    public static Triple createCommentOfProperty(String commentUri, String parentUri) {
+        return Triple.create(RdfUtils.uri(commentUri), commentOfProperty(), RdfUtils.uri(parentUri));
+    }
+
+    public static Triple createCommentIdentifierProperty(String commentUri, long identifier) {
+        return Triple.create(RdfUtils.uri(commentUri), commentIdentifierProperty(), RdfUtils.stringLiteral(Long.toString(identifier)));
+    }
+
+    public static Triple createCommentDescriptionProperty(String commentUri, String description) {
+        return Triple.create(RdfUtils.uri(commentUri), commentDescriptionProperty(), RdfUtils.stringLiteral(description));
+    }
+
+    public static Triple createCommentCreatedAtProperty(String commentUri, LocalDateTime createdAt) {
+        return Triple.create(RdfUtils.uri(commentUri), commentCreatedAtProperty(), RdfUtils.dateTimeLiteral(createdAt));
+    }
+
+    public static Triple createCommentAuthorProperty(String commentUri, String authorUri) {
+        return Triple.create(RdfUtils.uri(commentUri), commentAuthorProperty(), RdfUtils.uri(authorUri));
+    }
+
+    public static Triple createIsRootCommentProperty(String commentUri, boolean isRoot) {
+        return Triple.create(RdfUtils.uri(commentUri), isRootCommentProperty(), RdfUtils.stringLiteral(Boolean.toString(isRoot)));
+    }
+
+    public static Triple createCommentReplyCountProperty(String commentUri, long count) {
+        return Triple.create(RdfUtils.uri(commentUri), commentReplyCountProperty(), RdfUtils.nonNegativeIntegerLiteral(count));
+    }
+
+    public static Triple createHasCommentReplyProperty(String commentUri, String replyUri) {
+        return Triple.create(RdfUtils.uri(commentUri), hasCommentReplyProperty(), RdfUtils.uri(replyUri));
+    }
+
+    public static Triple createCommentReplyToProperty(String commentUri, String parentUri) {
+        return Triple.create(RdfUtils.uri(commentUri), commentReplyToProperty(), RdfUtils.uri(parentUri));
     }
 
 }


### PR DESCRIPTION
## Summary
- extend `RdfGithubIssueUtils` with merge info, review and comment properties
- add triple builders for new GitHub issue properties

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685faf313e10832b9dba18325788af68