### PR TITLE
Add GitHub review export

### DIFF
--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
@@ -58,6 +58,9 @@ import org.kohsuke.github.GHIssue;
 import org.kohsuke.github.GHIssueState;
 import org.kohsuke.github.GHMilestone;
 import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHPullRequestReview;
+import org.kohsuke.github.GHPullRequestReviewComment;
 import org.kohsuke.github.GitHub;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -78,6 +81,8 @@ import de.leipzig.htwk.gitrdf.worker.utils.ZipUtils;
 import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfCommitUtils;
 import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGitCommitUserUtils;
 import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGithubIssueUtils;
+import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGithubIssueReviewUtils;
+import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGithubIssueCommentUtils;
 import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
 
@@ -815,58 +820,105 @@ public class GithubRdfConversionTransactionService {
                             // rebased -> boolean if PR was rebase-merged
                         }
 
-                        // WORK HERE
-                        if (githubIssueRepositoryFilter.isEnableIssueReviewers()) {
-                            // Add to the github issue
-                            // github:hasReview ex:issue/12345/reviews/5001 ;
-                            // github:reviewCount 1 .
-                        }
+                        if (githubIssueRepositoryFilter.isEnableIssueReviewers() && ghIssue.isPullRequest()) {
+                            GHPullRequest pr = ghIssue.getRepository().getPullRequest(issueNumber);
+                            List<GHPullRequestReview> reviews = pr.listReviews().toList();
 
-                        // WORK HERE
-                        if (githubIssueRepositoryFilter.isEnableIssueComments()) {
-                            // Add to the github issue
-                            //github:hasComment ...issue/12345/comments/001 , ...issue/12345/comments/002 ;
-                            // github:commentCount 2 ;
-                        }
+                            String reviewContainerUri = githubIssueUri + "/reviews";
+                            writer.triple(RdfGithubIssueReviewUtils.createIssueReviewsProperty(githubIssueUri, reviewContainerUri));
+                            writer.triple(Triple.create(RdfUtils.uri(reviewContainerUri), RdfGithubIssueUtils.rdfTypeProperty(), RdfUtils.uri("github:ReviewContainer")));
+                            writer.triple(Triple.create(RdfUtils.uri(reviewContainerUri), RdfGithubIssueUtils.rdfTypeProperty(), RdfUtils.uri("rdf:Bag")));
 
+                            int reviewOrdinal = 1;
+                            int reviewCount = 0;
 
-                        if (githubIssueRepositoryFilter.isEnableIssueReviewers()) {
-                        // Add the Reviews and their comments to the main rdf as seperate uris under /issues/PR_ID/reviews/REVIEW_ID
-                        // issue/12345/reviews/5001
-                        //      rdf:type github:Review ;
-                        //      github:identifier "5001"^^xsd:string ;
-                        //      github:reviewOf ex:issue/12345 ;
-                        //      github:description "Looks good" ;
-                        //      github:state github:APPROVED ;
-                        //      github:createdAt "2025-06-26T20:00:00Z"^^xsd:dateTime ;
-                        //      github:updatedAt "2025-06-26T20:30:00Z"^^xsd:dateTime ;
-                        //      github:author ex:user/anna ;
-                        //      github:commitId "abc123def" ;
-                        //      github:authorAssociation github:COLLABORATOR ;
-                        //      github:reviewCommentCount 1 ;
-                        //      github:hasReviewComment ex:issue/12345/reviews/5001/comments/6001 .
+                            for (GHPullRequestReview review : reviews) {
+                                long reviewId = review.getId();
+                                if (!seenReviewIds.add(reviewId)) {
+                                    continue;
+                                }
+                                reviewCount++;
+                                String reviewUri = reviewContainerUri + "/" + reviewId;
 
-                            // ReviewComment is build in a separate method which should reflect a generalized way of creating comments for issues
-                        //  issue/12345/reviews/5001/comments/6001
-                        //     rdf:type github:ReviewComment ;
-                        //     github:identifier "6001"^^xsd:string ;
-                        //     github:description "Consider adding a test." ;
-                        //     github:createdAt "2025-06-26T20:05:00Z"^^xsd:dateTime ;
-                        //     github:author ex:user/ben ;
-                        //     github:isRootComment true ;
-                        //     github:commentReplyCount 1 ;
-                        //     github:hasCommentReply ex:issue/12345/reviews/5001/comments/6002 ;
-                        //     github:reviewCommentOf ex:issue/12345/reviews/5001 .
+                                writer.triple(RdfGithubIssueReviewUtils.createIssueHasReviewProperty(githubIssueUri, reviewUri));
+                                writer.triple(Triple.create(RdfUtils.uri(reviewContainerUri), RdfGithubIssueUtils.bagItemProperty(reviewOrdinal++), RdfUtils.uri(reviewUri)));
+                                writer.triple(Triple.create(RdfUtils.uri(reviewUri), RdfGithubIssueUtils.rdfTypeProperty(), RdfUtils.uri("github:Review")));
+                                writer.triple(RdfGithubIssueReviewUtils.createReviewIdentifierProperty(reviewUri, reviewId));
+                                writer.triple(RdfGithubIssueReviewUtils.createReviewOfProperty(reviewUri, githubIssueUri));
 
-                        // issue/12345/reviews/5001/comments/6002
-                        //     rdf:type github:ReviewComment ;
-                        //     github:identifier "6002"^^xsd:string ;
-                        //     github:description "Agreed, added one." ;
-                        //     github:createdAt "2025-06-26T20:10:00Z"^^xsd:dateTime ;
-                        //     github:author ex:user/anna ;
-                        //     github:isRootComment false ;
-                        //     github:reviewCommentReplyTo ex:issue/12345/reviews/5001/comments/6001 ;
-                        //     github:reviewCommentOf ex:issue/12345/reviews/5001 .
+                                if (review.getBody() != null && !review.getBody().isEmpty()) {
+                                    writer.triple(RdfGithubIssueReviewUtils.createReviewDescriptionProperty(reviewUri, review.getBody()));
+                                }
+                                if (review.getState() != null) {
+                                    writer.triple(RdfGithubIssueReviewUtils.createReviewStateProperty(reviewUri, review.getState().toString()));
+                                }
+                                if (review.getSubmittedAt() != null) {
+                                    writer.triple(RdfGithubIssueReviewUtils.createReviewCreatedAtProperty(reviewUri, localDateTimeFrom(review.getSubmittedAt())));
+                                }
+                                if (review.getLastEditedAt() != null) {
+                                    writer.triple(RdfGithubIssueReviewUtils.createReviewUpdatedAtProperty(reviewUri, localDateTimeFrom(review.getLastEditedAt())));
+                                }
+                                if (review.getUser() != null) {
+                                    writer.triple(RdfGithubIssueReviewUtils.createReviewAuthorProperty(reviewUri, review.getUser().getHtmlUrl().toString()));
+                                }
+                                if (review.getCommitId() != null) {
+                                    writer.triple(RdfGithubIssueReviewUtils.createReviewCommitIdProperty(reviewUri, review.getCommitId()));
+                                }
+                                if (review.getAuthorAssociation() != null) {
+                                    writer.triple(RdfGithubIssueReviewUtils.createReviewAuthorAssociationProperty(reviewUri, review.getAuthorAssociation()));
+                                }
+
+                                List<GHPullRequestReviewComment> reviewComments = review.listComments().toList();
+                                String commentContainerUri = reviewUri + "/comments";
+                                writer.triple(RdfGithubIssueReviewUtils.createDiscussionProperty(reviewUri, commentContainerUri));
+                                writer.triple(Triple.create(RdfUtils.uri(commentContainerUri), RdfGithubIssueUtils.rdfTypeProperty(), RdfUtils.uri("github:ReviewCommentContainer")));
+                                writer.triple(Triple.create(RdfUtils.uri(commentContainerUri), RdfGithubIssueUtils.rdfTypeProperty(), RdfUtils.uri("rdf:Bag")));
+
+                                int commentOrdinal = 1;
+                                int commentCount = 0;
+                                Map<Long, Integer> replyCount = new HashMap<>();
+
+                                for (GHPullRequestReviewComment c : reviewComments) {
+                                    long cid = c.getId();
+                                    String commentUri = commentContainerUri + "/" + cid;
+                                    writer.triple(Triple.create(RdfUtils.uri(commentContainerUri), RdfGithubIssueUtils.bagItemProperty(commentOrdinal++), RdfUtils.uri(commentUri)));
+                                    writer.triple(Triple.create(RdfUtils.uri(commentUri), RdfGithubIssueUtils.rdfTypeProperty(), RdfUtils.uri("github:ReviewComment")));
+                                    writer.triple(RdfGithubIssueCommentUtils.createCommentIdentifierProperty(commentUri, cid));
+                                    if (c.getBody() != null) {
+                                        writer.triple(RdfGithubIssueCommentUtils.createCommentDescriptionProperty(commentUri, c.getBody()));
+                                    }
+                                    if (c.getUser() != null) {
+                                        writer.triple(RdfGithubIssueCommentUtils.createCommentAuthorProperty(commentUri, c.getUser().getHtmlUrl().toString()));
+                                    }
+                                    if (c.getCreatedAt() != null) {
+                                        writer.triple(RdfGithubIssueCommentUtils.createCommentCreatedAtProperty(commentUri, localDateTimeFrom(c.getCreatedAt())));
+                                    }
+                                    writer.triple(RdfGithubIssueCommentUtils.createReviewCommentOfProperty(commentUri, reviewUri));
+
+                                    Long replyTo = c.getInReplyToId();
+                                    if (replyTo == null) {
+                                        writer.triple(RdfGithubIssueCommentUtils.createCommentIsRootProperty(commentUri, true));
+                                        replyCount.put(cid, 0);
+                                    } else {
+                                        writer.triple(RdfGithubIssueCommentUtils.createCommentIsRootProperty(commentUri, false));
+                                        String parentUri = commentContainerUri + "/" + replyTo;
+                                        writer.triple(RdfGithubIssueCommentUtils.createReviewCommentReplyToProperty(commentUri, parentUri));
+                                        writer.triple(RdfGithubIssueCommentUtils.createHasCommentReplyProperty(parentUri, commentUri));
+                                        replyCount.compute(replyTo, (k,v) -> v == null ? 1 : v + 1);
+                                    }
+
+                                    commentCount++;
+                                }
+
+                                for (Map.Entry<Long, Integer> e : replyCount.entrySet()) {
+                                    String cUri = commentContainerUri + "/" + e.getKey();
+                                    writer.triple(RdfGithubIssueCommentUtils.createCommentReplyCountProperty(cUri, e.getValue()));
+                                }
+
+                                writer.triple(RdfGithubIssueReviewUtils.createReviewCommentCountProperty(reviewUri, commentCount));
+                            }
+
+                            writer.triple(RdfGithubIssueReviewUtils.createIssueReviewCountProperty(githubIssueUri, reviewCount));
                         }
 
 

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueCommentUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueCommentUtils.java
@@ -1,0 +1,62 @@
+package de.leipzig.htwk.gitrdf.worker.utils.rdf;
+
+import static de.leipzig.htwk.gitrdf.worker.service.impl.GithubRdfConversionTransactionService.PLATFORM_GITHUB_NAMESPACE;
+import static de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfUtils.uri;
+
+import java.time.LocalDateTime;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.Triple;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class RdfGithubIssueCommentUtils {
+
+    private static final String GH_NS = PLATFORM_GITHUB_NAMESPACE + ":";
+
+    public static Node identifierProperty() { return uri(GH_NS + "identifier"); }
+    public static Node descriptionProperty() { return uri(GH_NS + "description"); }
+    public static Node isRootCommentProperty() { return uri(GH_NS + "isRootComment"); }
+    public static Node commentReplyCountProperty() { return uri(GH_NS + "commentReplyCount"); }
+    public static Node hasCommentReplyProperty() { return uri(GH_NS + "hasCommentReply"); }
+    public static Node reviewCommentOfProperty() { return uri(GH_NS + "reviewCommentOf"); }
+    public static Node reviewCommentReplyToProperty() { return uri(GH_NS + "reviewCommentReplyTo"); }
+
+    public static Triple createCommentIdentifierProperty(String commentUri, long id) {
+        return Triple.create(uri(commentUri), identifierProperty(), RdfUtils.longLiteral(id));
+    }
+
+    public static Triple createCommentDescriptionProperty(String commentUri, String body) {
+        return Triple.create(uri(commentUri), descriptionProperty(), RdfUtils.stringLiteral(body));
+    }
+
+    public static Triple createCommentAuthorProperty(String commentUri, String authorUri) {
+        return Triple.create(uri(commentUri), RdfGithubIssueUtils.authorProperty(), uri(authorUri));
+    }
+
+    public static Triple createCommentCreatedAtProperty(String commentUri, LocalDateTime createdAt) {
+        return Triple.create(uri(commentUri), RdfGithubIssueUtils.createdAtProperty(), RdfUtils.dateTimeLiteral(createdAt));
+    }
+
+    public static Triple createCommentIsRootProperty(String commentUri, boolean root) {
+        return Triple.create(uri(commentUri), isRootCommentProperty(), RdfUtils.booleanLiteral(root));
+    }
+
+    public static Triple createCommentReplyCountProperty(String commentUri, long count) {
+        return Triple.create(uri(commentUri), commentReplyCountProperty(), RdfUtils.nonNegativeIntegerLiteral(count));
+    }
+
+    public static Triple createHasCommentReplyProperty(String commentUri, String replyUri) {
+        return Triple.create(uri(commentUri), hasCommentReplyProperty(), uri(replyUri));
+    }
+
+    public static Triple createReviewCommentOfProperty(String commentUri, String reviewUri) {
+        return Triple.create(uri(commentUri), reviewCommentOfProperty(), uri(reviewUri));
+    }
+
+    public static Triple createReviewCommentReplyToProperty(String commentUri, String parentUri) {
+        return Triple.create(uri(commentUri), reviewCommentReplyToProperty(), uri(parentUri));
+    }
+}

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueReviewUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueReviewUtils.java
@@ -1,0 +1,90 @@
+package de.leipzig.htwk.gitrdf.worker.utils.rdf;
+
+import static de.leipzig.htwk.gitrdf.worker.service.impl.GithubRdfConversionTransactionService.PLATFORM_GITHUB_NAMESPACE;
+import static de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfUtils.uri;
+
+import java.time.LocalDateTime;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.Triple;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class RdfGithubIssueReviewUtils {
+
+    private static final String GH_NS = PLATFORM_GITHUB_NAMESPACE + ":";
+
+    public static Node reviewsProperty() { return uri(GH_NS + "reviews"); }
+    public static Node hasReviewProperty() { return uri(GH_NS + "hasReview"); }
+    public static Node reviewCountProperty() { return uri(GH_NS + "reviewCount"); }
+    public static Node reviewOfProperty() { return uri(GH_NS + "reviewOf"); }
+    public static Node identifierProperty() { return uri(GH_NS + "identifier"); }
+    public static Node descriptionProperty() { return uri(GH_NS + "description"); }
+    public static Node commitIdProperty() { return uri(GH_NS + "commitId"); }
+    public static Node authorAssociationProperty() { return uri(GH_NS + "authorAssociation"); }
+    public static Node reviewCommentCountProperty() { return uri(GH_NS + "reviewCommentCount"); }
+    public static Node hasReviewCommentProperty() { return uri(GH_NS + "hasReviewComment"); }
+    public static Node discussionProperty() { return uri(GH_NS + "discussion"); }
+
+    public static Triple createIssueReviewsProperty(String issueUri, String containerUri) {
+        return Triple.create(uri(issueUri), reviewsProperty(), uri(containerUri));
+    }
+
+    public static Triple createIssueHasReviewProperty(String issueUri, String reviewUri) {
+        return Triple.create(uri(issueUri), hasReviewProperty(), uri(reviewUri));
+    }
+
+    public static Triple createIssueReviewCountProperty(String issueUri, long count) {
+        return Triple.create(uri(issueUri), reviewCountProperty(), RdfUtils.nonNegativeIntegerLiteral(count));
+    }
+
+    public static Triple createReviewIdentifierProperty(String reviewUri, long id) {
+        return Triple.create(uri(reviewUri), identifierProperty(), RdfUtils.longLiteral(id));
+    }
+
+    public static Triple createReviewOfProperty(String reviewUri, String issueUri) {
+        return Triple.create(uri(reviewUri), reviewOfProperty(), uri(issueUri));
+    }
+
+    public static Triple createReviewDescriptionProperty(String reviewUri, String body) {
+        return Triple.create(uri(reviewUri), descriptionProperty(), RdfUtils.stringLiteral(body));
+    }
+
+    public static Triple createReviewStateProperty(String reviewUri, String state) {
+        return Triple.create(uri(reviewUri), RdfGithubIssueUtils.stateProperty(), uri(state.toLowerCase()));
+    }
+
+    public static Triple createReviewCreatedAtProperty(String reviewUri, LocalDateTime createdAt) {
+        return Triple.create(uri(reviewUri), RdfGithubIssueUtils.createdAtProperty(), RdfUtils.dateTimeLiteral(createdAt));
+    }
+
+    public static Triple createReviewUpdatedAtProperty(String reviewUri, LocalDateTime updatedAt) {
+        return Triple.create(uri(reviewUri), RdfGithubIssueUtils.updatedAtProperty(), RdfUtils.dateTimeLiteral(updatedAt));
+    }
+
+    public static Triple createReviewAuthorProperty(String reviewUri, String authorUri) {
+        return Triple.create(uri(reviewUri), RdfGithubIssueUtils.authorProperty(), uri(authorUri));
+    }
+
+    public static Triple createReviewCommitIdProperty(String reviewUri, String commitId) {
+        return Triple.create(uri(reviewUri), commitIdProperty(), RdfUtils.stringLiteral(commitId));
+    }
+
+    public static Triple createReviewAuthorAssociationProperty(String reviewUri, String association) {
+        return Triple.create(uri(reviewUri), authorAssociationProperty(), uri(association.toLowerCase()));
+    }
+
+    public static Triple createReviewCommentCountProperty(String reviewUri, long count) {
+        return Triple.create(uri(reviewUri), reviewCommentCountProperty(), RdfUtils.nonNegativeIntegerLiteral(count));
+    }
+
+    public static Triple createReviewHasCommentProperty(String reviewUri, String commentUri) {
+        return Triple.create(uri(reviewUri), hasReviewCommentProperty(), uri(commentUri));
+    }
+
+    public static Triple createDiscussionProperty(String parentUri, String discussionUri) {
+        return Triple.create(uri(parentUri), discussionProperty(), uri(discussionUri));
+    }
+}

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueUtils.java
@@ -127,5 +127,4 @@ public final class RdfGithubIssueUtils {
     public static Triple createIssueRepositoryProperty(String issueUri, String repoUri) {
         return Triple.create(RdfUtils.uri(issueUri), repositoryProperty(), RdfUtils.uri(repoUri));
     }
-
 }

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfUtils.java
@@ -62,6 +62,10 @@ public final class RdfUtils {
         return NodeFactory.createLiteralByValue(value, XSDDatatype.XSDnonNegativeInteger);
     }
 
+    public static Node booleanLiteral(boolean value) {
+        return NodeFactory.createLiteralByValue(value, XSDDatatype.XSDboolean);
+    }
+
     public static Node uri(String value) {
         var expandedValue = prefixMap.expand(value);
 


### PR DESCRIPTION
## Summary
- support boolean RDF literal creation
- expose review and review comment helpers
- export pull request reviews and comments when enabled
- split comment & review utilities into separate classes

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685faf53ae04832b8fb0370160bfd6e8