### PR TITLE
Remove review count triples

### DIFF
--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
@@ -871,14 +871,12 @@ public class GithubRdfConversionTransactionService {
 
 
                             int reviewOrdinal = 1;
-                            int reviewCount = 0;
 
                             for (GHPullRequestReview review : reviews) {
                                 long reviewId = review.getId();
                                 if (!seenReviewIds.add(reviewId)) {
                                     continue;
                                 }
-                                reviewCount++;
                                 String reviewUri = reviewContainerUri + "/" + reviewId;
 
                                 writer.triple(RdfGithubIssueReviewUtils.createIssueHasReviewProperty(githubIssueUri, reviewUri));
@@ -919,7 +917,6 @@ public class GithubRdfConversionTransactionService {
 
 
                                 int commentOrdinal = 1;
-                                int commentCount = 0;
                                 Map<Long, Integer> replyCount = new HashMap<>();
 
                                 for (GHPullRequestReviewComment c : reviewComments) {
@@ -953,7 +950,6 @@ public class GithubRdfConversionTransactionService {
                                         replyCount.compute(replyTo, (k,v) -> v == null ? 1 : v + 1);
                                     }
 
-                                    commentCount++;
                                 }
 
                                 for (Map.Entry<Long, Integer> e : replyCount.entrySet()) {
@@ -961,11 +957,9 @@ public class GithubRdfConversionTransactionService {
                                     writer.triple(RdfGithubIssueCommentUtils.createCommentReplyCountProperty(cUri, e.getValue()));
                                 }
 
-                                writer.triple(RdfGithubIssueReviewUtils.createReviewCommentCountProperty(reviewUri, commentCount));
                             }
 
 
-                            writer.triple(RdfGithubIssueReviewUtils.createIssueReviewCountProperty(githubIssueUri, reviewCount));
 
                         }
 

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueReviewUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueReviewUtils.java
@@ -18,13 +18,11 @@ public final class RdfGithubIssueReviewUtils {
 
     public static Node reviewsProperty() { return uri(GH_NS + "reviews"); }
     public static Node hasReviewProperty() { return uri(GH_NS + "hasReview"); }
-    public static Node reviewCountProperty() { return uri(GH_NS + "reviewCount"); }
     public static Node reviewOfProperty() { return uri(GH_NS + "reviewOf"); }
     public static Node identifierProperty() { return uri(GH_NS + "identifier"); }
     public static Node descriptionProperty() { return uri(GH_NS + "description"); }
     public static Node commitIdProperty() { return uri(GH_NS + "commitId"); }
     public static Node authorAssociationProperty() { return uri(GH_NS + "authorAssociation"); }
-    public static Node reviewCommentCountProperty() { return uri(GH_NS + "reviewCommentCount"); }
     public static Node hasReviewCommentProperty() { return uri(GH_NS + "hasReviewComment"); }
     public static Node discussionProperty() { return uri(GH_NS + "discussion"); }
 
@@ -42,9 +40,6 @@ public final class RdfGithubIssueReviewUtils {
         return Triple.create(uri(issueUri), hasReviewProperty(), uri(reviewUri));
     }
 
-    public static Triple createIssueReviewCountProperty(String issueUri, long count) {
-        return Triple.create(uri(issueUri), reviewCountProperty(), RdfUtils.nonNegativeIntegerLiteral(count));
-    }
 
     public static Triple createReviewIdentifierProperty(String reviewUri, long id) {
         return Triple.create(uri(reviewUri), identifierProperty(), RdfUtils.longLiteral(id));
@@ -82,9 +77,6 @@ public final class RdfGithubIssueReviewUtils {
         return Triple.create(uri(reviewUri), authorAssociationProperty(), uri(association.toLowerCase()));
     }
 
-    public static Triple createReviewCommentCountProperty(String reviewUri, long count) {
-        return Triple.create(uri(reviewUri), reviewCommentCountProperty(), RdfUtils.nonNegativeIntegerLiteral(count));
-    }
 
     public static Triple createReviewHasCommentProperty(String reviewUri, String commentUri) {
         return Triple.create(uri(reviewUri), hasReviewCommentProperty(), uri(commentUri));


### PR DESCRIPTION
## Summary
- clean up `RdfGithubIssueReviewUtils` to drop review count helpers
- remove writing of review count triples during Github conversion

## Testing
- `mvn test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685fda1e44c8832ba1b47cf2303dddff