### PR TITLE
Simplify review listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ Reviews expose their comments via a dedicated container located at `#comments` r
 [New Spring Initializr Template](https://start.spring.io/#!type=maven-project&language=java&platformVersion=3.2.2&packaging=jar&jvmVersion=21&groupId=de.leipzig.htwk.gitrdf&artifactId=worker&name=worker&description=Archetype%20project%20for%20HTWK%20Leipzig%20-%20Project%20to%20transform%20git%20to%20RDF&packageName=de.leipzig.htwk.gitrdf.worker&dependencies=lombok,devtools,data-jpa,postgresql,testcontainers,integration,flyway)
 
 
-## Review Container Example
+## Review List Example
 
-Pull request reviews are now grouped inside a dedicated container.
+Pull request reviews are now collected in a simple list resource.
 
 ```turtle
 <#pr123> github:reviews <#pr123/reviews> .
 
-<#pr123/reviews> a github:ReviewContainer, rdf:Bag ;
+<#pr123/reviews>
     rdf:_1 <#pr123/reviews/1> ;
     rdf:_2 <#pr123/reviews/2> .
 ```

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import org.apache.commons.lang3.time.StopWatch;
 import org.apache.jena.graph.Node;
+import org.apache.jena.graph.Triple;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.riot.RDFFormat;
@@ -84,6 +85,7 @@ import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGitCommitUserUtils;
 import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGithubIssueUtils;
 import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGithubIssueReviewUtils;
 import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGithubIssueCommentUtils;
+import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfUtils;
 import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
 
@@ -864,10 +866,11 @@ public class GithubRdfConversionTransactionService {
                             GHPullRequest pr = ghIssue.getRepository().getPullRequest(issueNumber);
                             List<GHPullRequestReview> reviews = pr.listReviews().toList();
 
-                            String reviewContainerUri = githubIssueUri + "/reviews";
-                            writer.triple(RdfGithubIssueReviewUtils.createIssueReviewsProperty(githubIssueUri, reviewContainerUri));
-
-                            writer.triple(RdfGithubIssueReviewUtils.createReviewContainerRdfTypeProperty(reviewContainerUri));
+                            String reviewListUri = githubIssueUri + "/reviews";
+                            writer.triple(Triple.create(
+                                    RdfUtils.uri(githubIssueUri),
+                                    RdfGithubIssueReviewUtils.reviewsProperty(),
+                                    RdfUtils.uri(reviewListUri)));
 
 
                             int reviewOrdinal = 1;
@@ -879,11 +882,11 @@ public class GithubRdfConversionTransactionService {
                                     continue;
                                 }
                                 reviewCount++;
-                                String reviewUri = reviewContainerUri + "/" + reviewId;
+                                String reviewUri = reviewListUri + "/" + reviewId;
 
                                 writer.triple(RdfGithubIssueReviewUtils.createIssueHasReviewProperty(githubIssueUri, reviewUri));
 
-                                writer.triple(RdfGithubIssueReviewUtils.createContainerMembershipProperty(reviewContainerUri, reviewOrdinal++, reviewUri));
+                                writer.triple(RdfGithubIssueReviewUtils.createContainerMembershipProperty(reviewListUri, reviewOrdinal++, reviewUri));
                                 writer.triple(RdfGithubIssueReviewUtils.createReviewRdfTypeProperty(reviewUri));
 
                                 writer.triple(RdfGithubIssueReviewUtils.createReviewIdentifierProperty(reviewUri, reviewId));

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueReviewUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueReviewUtils.java
@@ -28,15 +28,11 @@ public final class RdfGithubIssueReviewUtils {
     public static Node hasReviewCommentProperty() { return uri(GH_NS + "hasReviewComment"); }
     public static Node discussionProperty() { return uri(GH_NS + "discussion"); }
 
-    public static Node reviewContainerClass() { return uri(GH_NS + "ReviewContainer"); }
     public static Node reviewCommentContainerClass() { return uri(GH_NS + "ReviewCommentContainer"); }
     public static Node reviewClass() { return uri(GH_NS + "Review"); }
     public static Node reviewCommentClass() { return uri(GH_NS + "ReviewComment"); }
 
 
-    public static Triple createIssueReviewsProperty(String issueUri, String containerUri) {
-        return Triple.create(uri(issueUri), reviewsProperty(), uri(containerUri));
-    }
 
     public static Triple createIssueHasReviewProperty(String issueUri, String reviewUri) {
         return Triple.create(uri(issueUri), hasReviewProperty(), uri(reviewUri));
@@ -94,10 +90,6 @@ public final class RdfGithubIssueReviewUtils {
         return Triple.create(uri(parentUri), discussionProperty(), uri(discussionUri));
     }
 
-
-    public static Triple createReviewContainerRdfTypeProperty(String containerUri) {
-        return Triple.create(uri(containerUri), RdfGithubIssueUtils.rdfTypeProperty(), reviewContainerClass());
-    }
 
     public static Triple createReviewCommentContainerRdfTypeProperty(String containerUri) {
         return Triple.create(uri(containerUri), RdfGithubIssueUtils.rdfTypeProperty(), reviewCommentContainerClass());


### PR DESCRIPTION
## Summary
- drop ReviewContainer artifacts
- list reviews directly using rdf:_n
- update conversion service to write new list
- document review list structure

## Testing
- `./mvnw -q -DskipTests package` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685fda214d2c832bb08847db35b2892d