### PR TITLE
Fix review comment processing

### DIFF
--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
@@ -901,9 +901,6 @@ public class GithubRdfConversionTransactionService {
                                 if (review.getSubmittedAt() != null) {
                                     writer.triple(RdfGithubIssueReviewUtils.createReviewCreatedAtProperty(reviewUri, localDateTimeFrom(review.getSubmittedAt())));
                                 }
-                                if (review.getLastEditedAt() != null) {
-                                    writer.triple(RdfGithubIssueReviewUtils.createReviewUpdatedAtProperty(reviewUri, localDateTimeFrom(review.getLastEditedAt())));
-                                }
                                 if (review.getUser() != null) {
                                     writer.triple(RdfGithubIssueReviewUtils.createReviewAuthorProperty(reviewUri, review.getUser().getHtmlUrl().toString()));
                                 }
@@ -911,33 +908,27 @@ public class GithubRdfConversionTransactionService {
                                     writer.triple(RdfGithubIssueReviewUtils.createReviewCommitIdProperty(reviewUri, review.getCommitId()));
                                 }
                                 if (review.getAuthorAssociation() != null) {
-                                    writer.triple(RdfGithubIssueReviewUtils.createReviewAuthorAssociationProperty(reviewUri, review.getAuthorAssociation()));
+                                    writer.triple(RdfGithubIssueReviewUtils.createReviewAuthorAssociationProperty(reviewUri, review.getAuthorAssociation().toString()));
                                 }
 
                                 List<GHPullRequestReviewComment> reviewComments = review.listComments().toList();
 
                                 String commentContainerUri = reviewUri + "/comments";
                                 writer.triple(RdfGithubIssueReviewUtils.createDiscussionProperty(reviewUri, commentContainerUri));
-
                                 writer.triple(RdfGithubIssueCommentUtils.createReviewCommentContainerRdfTypeProperty(commentContainerUri));
 
-
-                         
                                 Map<Long, Integer> replyCount = new HashMap<>();
-
+                                int commentOrdinal = 1;
 
                                 if (!reviewComments.isEmpty()) {
-                                    writer.triple(RdfGithubIssueReviewUtils.createDiscussionProperty(reviewUri, commentContainerUri));
-                                    writer.triple(RdfGithubIssueCommentUtils.createReviewCommentContainerRdfTypeProperty(commentContainerUri));
-
-                          
-                                    Map<Long, Integer> replyCount = new HashMap<>();
 
                                     for (GHPullRequestReviewComment c : reviewComments) {
                                         long cid = c.getId();
                                         String commentUri = commentContainerUri + "/" + cid;
 
-                                        writer.triple(RdfGithubIssueReviewUtils.createContainerMembershipProperty(commentContainerUri, commentOrdinal++, commentUri));
+                                        writer.triple(RdfGithubIssueReviewUtils.createContainerMembershipProperty(commentContainerUri, commentOrdinal, commentUri));
+                                        commentOrdinal++;
+                                        writer.triple(RdfGithubIssueReviewUtils.createReviewHasCommentProperty(reviewUri, commentUri));
                                         writer.triple(RdfGithubIssueCommentUtils.createReviewCommentRdfTypeProperty(commentUri));
 
                                         writer.triple(RdfGithubIssueCommentUtils.createCommentIdentifierProperty(commentUri, cid));


### PR DESCRIPTION
## Summary
- link reviews to comments and remove duplicate container setup
- use consistent reply counting logic
- remove unsupported lastEditedAt call
- serialize authorAssociation correctly

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685fe06617c0832bbf0f87f7115eddb1