### PR TITLE
Refactor review comments representation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See the folder `target` for the executable JAR file.
 
 ## Discussion containers
 
-Reviews expose their comments via a dedicated container located at `#comments` relative to the parent resource. The parent links to this container via `github:discussion`. The container is typed as `rdf:Bag` and enumerates comment URIs using ordinal properties like `rdf:_1`, `rdf:_2`.
+Reviews expose their comments via the `github:comments` property on the review itself. The property points to an `rdf:Bag` list that enumerates comment URIs with ordinal predicates such as `rdf:_1`, `rdf:_2`. The `github:discussion` property is only used for nested reply threads.
 
 [Spring Initializr Template](https://start.spring.io/#!type=maven-project&language=java&platformVersion=3.2.2&packaging=jar&jvmVersion=21&groupId=de.leipzig.htwk.gitrdf&artifactId=worker&name=worker&description=Archetype%20project%20for%20HTWK%20Leipzig%20-%20Project%20to%20transform%20git%20to%20RDF&packageName=de.leipzig.htwk.gitrdf.worker&dependencies=lombok,devtools,data-jpa,postgresql,testcontainers,integration)
 
@@ -57,6 +57,16 @@ Pull request reviews are now grouped inside a dedicated container.
 <#pr123/reviews> a github:ReviewContainer, rdf:Bag ;
     rdf:_1 <#pr123/reviews/1> ;
     rdf:_2 <#pr123/reviews/2> .
+```
+
+## Comment List Example
+
+```turtle
+<#pr123/reviews/1> github:comments <#pr123/reviews/1#comments> .
+
+<#pr123/reviews/1#comments> a rdf:Bag ;
+    rdf:_1 <#pr123/reviews/1/comments/1> ;
+    rdf:_2 <#pr123/reviews/1/comments/2> .
 ```
 
 

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
@@ -912,10 +912,9 @@ public class GithubRdfConversionTransactionService {
                                 }
 
                                 List<GHPullRequestReviewComment> reviewComments = review.listComments().toList();
-                                String commentContainerUri = reviewUri + "/comments";
-                                writer.triple(RdfGithubIssueReviewUtils.createDiscussionProperty(reviewUri, commentContainerUri));
-
-                                writer.triple(RdfGithubIssueCommentUtils.createReviewCommentContainerRdfTypeProperty(commentContainerUri));
+                                String commentListUri = reviewUri + "#comments";
+                                writer.triple(RdfGithubIssueReviewUtils.createReviewCommentsProperty(reviewUri, commentListUri));
+                                writer.triple(RdfGithubIssueReviewUtils.createCommentListRdfTypeProperty(commentListUri));
 
 
                                 int commentOrdinal = 1;
@@ -924,9 +923,9 @@ public class GithubRdfConversionTransactionService {
 
                                 for (GHPullRequestReviewComment c : reviewComments) {
                                     long cid = c.getId();
-                                    String commentUri = commentContainerUri + "/" + cid;
+                                    String commentUri = commentListUri + "/" + cid;
 
-                                    writer.triple(RdfGithubIssueReviewUtils.createContainerMembershipProperty(commentContainerUri, commentOrdinal++, commentUri));
+                                    writer.triple(RdfGithubIssueReviewUtils.createContainerMembershipProperty(commentListUri, commentOrdinal++, commentUri));
                                     writer.triple(RdfGithubIssueCommentUtils.createReviewCommentRdfTypeProperty(commentUri));
 
                                     writer.triple(RdfGithubIssueCommentUtils.createCommentIdentifierProperty(commentUri, cid));
@@ -947,7 +946,7 @@ public class GithubRdfConversionTransactionService {
                                         replyCount.put(cid, 0);
                                     } else {
                                         writer.triple(RdfGithubIssueCommentUtils.createCommentIsRootProperty(commentUri, false));
-                                        String parentUri = commentContainerUri + "/" + replyTo;
+                                        String parentUri = commentListUri + "/" + replyTo;
                                         writer.triple(RdfGithubIssueCommentUtils.createReviewCommentReplyToProperty(commentUri, parentUri));
                                         writer.triple(RdfGithubIssueCommentUtils.createHasCommentReplyProperty(parentUri, commentUri));
                                         replyCount.compute(replyTo, (k,v) -> v == null ? 1 : v + 1);
@@ -957,7 +956,7 @@ public class GithubRdfConversionTransactionService {
                                 }
 
                                 for (Map.Entry<Long, Integer> e : replyCount.entrySet()) {
-                                    String cUri = commentContainerUri + "/" + e.getKey();
+                                    String cUri = commentListUri + "/" + e.getKey();
                                     writer.triple(RdfGithubIssueCommentUtils.createCommentReplyCountProperty(cUri, e.getValue()));
                                 }
 

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueReviewUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueReviewUtils.java
@@ -27,6 +27,7 @@ public final class RdfGithubIssueReviewUtils {
     public static Node reviewCommentCountProperty() { return uri(GH_NS + "reviewCommentCount"); }
     public static Node hasReviewCommentProperty() { return uri(GH_NS + "hasReviewComment"); }
     public static Node discussionProperty() { return uri(GH_NS + "discussion"); }
+    public static Node commentsProperty() { return uri(GH_NS + "comments"); }
 
     public static Node reviewContainerClass() { return uri(GH_NS + "ReviewContainer"); }
     public static Node reviewCommentContainerClass() { return uri(GH_NS + "ReviewCommentContainer"); }
@@ -88,6 +89,14 @@ public final class RdfGithubIssueReviewUtils {
 
     public static Triple createReviewHasCommentProperty(String reviewUri, String commentUri) {
         return Triple.create(uri(reviewUri), hasReviewCommentProperty(), uri(commentUri));
+    }
+
+    public static Triple createReviewCommentsProperty(String reviewUri, String listUri) {
+        return Triple.create(uri(reviewUri), commentsProperty(), uri(listUri));
+    }
+
+    public static Triple createCommentListRdfTypeProperty(String listUri) {
+        return Triple.create(uri(listUri), RdfGithubIssueUtils.rdfTypeProperty(), RdfUtils.uri("rdf:Bag"));
     }
 
     public static Triple createDiscussionProperty(String parentUri, String discussionUri) {


### PR DESCRIPTION
## Summary
- expose review comments via a github:comments list
- drop use of the comments container for reviews
- keep discussion only for nested replies
- document new comment list

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685fda2d043c832baa153061c7950070