### PR TITLE
Fix RDF structure for reviews and comments

### DIFF
--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueCommentUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueCommentUtils.java
@@ -19,13 +19,11 @@ public final class RdfGithubIssueCommentUtils {
     public static Node identifierProperty() { return uri(GH_NS + "identifier"); }
     public static Node descriptionProperty() { return uri(GH_NS + "description"); }
     public static Node isRootCommentProperty() { return uri(GH_NS + "isRootComment"); }
-    public static Node commentReplyCountProperty() { return uri(GH_NS + "commentReplyCount"); }
     public static Node hasCommentReplyProperty() { return uri(GH_NS + "hasCommentReply"); }
     public static Node reviewCommentOfProperty() { return uri(GH_NS + "reviewCommentOf"); }
     public static Node reviewCommentReplyToProperty() { return uri(GH_NS + "reviewCommentReplyTo"); }
 
     public static Node reviewCommentClass() { return uri(GH_NS + "ReviewComment"); }
-    public static Node reviewCommentContainerClass() { return uri(GH_NS + "ReviewCommentContainer"); }
 
 
     public static Triple createCommentIdentifierProperty(String commentUri, long id) {
@@ -48,10 +46,6 @@ public final class RdfGithubIssueCommentUtils {
         return Triple.create(uri(commentUri), isRootCommentProperty(), RdfUtils.booleanLiteral(root));
     }
 
-    public static Triple createCommentReplyCountProperty(String commentUri, long count) {
-        return Triple.create(uri(commentUri), commentReplyCountProperty(), RdfUtils.nonNegativeIntegerLiteral(count));
-    }
-
     public static Triple createHasCommentReplyProperty(String commentUri, String replyUri) {
         return Triple.create(uri(commentUri), hasCommentReplyProperty(), uri(replyUri));
     }
@@ -67,10 +61,6 @@ public final class RdfGithubIssueCommentUtils {
 
     public static Triple createReviewCommentRdfTypeProperty(String commentUri) {
         return Triple.create(uri(commentUri), RdfGithubIssueUtils.rdfTypeProperty(), reviewCommentClass());
-    }
-
-    public static Triple createReviewCommentContainerRdfTypeProperty(String containerUri) {
-        return Triple.create(uri(containerUri), RdfGithubIssueUtils.rdfTypeProperty(), reviewCommentContainerClass());
     }
 
 }

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueReviewUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueReviewUtils.java
@@ -22,13 +22,10 @@ public final class RdfGithubIssueReviewUtils {
     public static Node identifierProperty() { return uri(GH_NS + "identifier"); }
     public static Node descriptionProperty() { return uri(GH_NS + "description"); }
     public static Node commitIdProperty() { return uri(GH_NS + "commitId"); }
-    public static Node authorAssociationProperty() { return uri(GH_NS + "authorAssociation"); }
     public static Node hasReviewCommentProperty() { return uri(GH_NS + "hasReviewComment"); }
     public static Node discussionProperty() { return uri(GH_NS + "discussion"); }
 
-    public static Node reviewCommentContainerClass() { return uri(GH_NS + "ReviewCommentContainer"); }
     public static Node reviewClass() { return uri(GH_NS + "Review"); }
-    public static Node reviewCommentClass() { return uri(GH_NS + "ReviewComment"); }
 
 
 
@@ -57,10 +54,6 @@ public final class RdfGithubIssueReviewUtils {
         return Triple.create(uri(reviewUri), RdfGithubIssueUtils.createdAtProperty(), RdfUtils.dateTimeLiteral(createdAt));
     }
 
-    public static Triple createReviewUpdatedAtProperty(String reviewUri, LocalDateTime updatedAt) {
-        return Triple.create(uri(reviewUri), RdfGithubIssueUtils.updatedAtProperty(), RdfUtils.dateTimeLiteral(updatedAt));
-    }
-
     public static Triple createReviewCreatorProperty(String reviewUri, String creatorUri) {
         return Triple.create(uri(reviewUri), RdfGithubIssueUtils.creatorProperty(), uri(creatorUri));
     }
@@ -68,11 +61,6 @@ public final class RdfGithubIssueReviewUtils {
     public static Triple createReviewCommitIdProperty(String reviewUri, String commitId) {
         return Triple.create(uri(reviewUri), commitIdProperty(), RdfUtils.stringLiteral(commitId));
     }
-
-    public static Triple createReviewAuthorAssociationProperty(String reviewUri, String association) {
-        return Triple.create(uri(reviewUri), authorAssociationProperty(), uri(association.toLowerCase()));
-    }
-
 
     public static Triple createReviewHasCommentProperty(String reviewUri, String commentUri) {
         return Triple.create(uri(reviewUri), hasReviewCommentProperty(), uri(commentUri));
@@ -83,20 +71,8 @@ public final class RdfGithubIssueReviewUtils {
     }
 
 
-    public static Triple createReviewCommentContainerRdfTypeProperty(String containerUri) {
-        return Triple.create(uri(containerUri), RdfGithubIssueUtils.rdfTypeProperty(), reviewCommentContainerClass());
-    }
-
     public static Triple createReviewRdfTypeProperty(String reviewUri) {
         return Triple.create(uri(reviewUri), RdfGithubIssueUtils.rdfTypeProperty(), reviewClass());
-    }
-
-    public static Triple createReviewCommentRdfTypeProperty(String commentUri) {
-        return Triple.create(uri(commentUri), RdfGithubIssueUtils.rdfTypeProperty(), reviewCommentClass());
-    }
-
-    public static Triple createContainerMembershipProperty(String containerUri, int ordinal, String elementUri) {
-        return Triple.create(uri(containerUri), RdfGithubIssueUtils.bagItemProperty(ordinal), uri(elementUri));
     }
 
 }

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueUtils.java
@@ -88,7 +88,6 @@ public final class RdfGithubIssueUtils {
     // Review linkage
     public static Node hasReviewProperty() { return RdfUtils.uri(GH_NS + "hasReview"); }
 
-    public static Node reviewCountProperty() { return RdfUtils.uri(GH_NS + "reviewCount"); }
 
     public static Node reviewContainerProperty() { return RdfUtils.uri(GH_NS + "reviewContainer"); }
 
@@ -109,14 +108,12 @@ public final class RdfGithubIssueUtils {
 
     public static Node authorAssociationProperty() { return RdfUtils.uri(GH_NS + "authorAssociation"); }
 
-    public static Node reviewCommentCountProperty() { return RdfUtils.uri(GH_NS + "reviewCommentCount"); }
 
     public static Node hasReviewCommentProperty() { return RdfUtils.uri(GH_NS + "hasReviewComment"); }
 
     // Comment linkage
     public static Node hasCommentProperty() { return RdfUtils.uri(GH_NS + "hasComment"); }
 
-    public static Node commentCountProperty() { return RdfUtils.uri(GH_NS + "commentCount"); }
 
     public static Node discussionProperty() { return RdfUtils.uri(GH_NS + "discussion"); }
 
@@ -133,7 +130,6 @@ public final class RdfGithubIssueUtils {
 
     public static Node isRootCommentProperty() { return RdfUtils.uri(GH_NS + "isRootComment"); }
 
-    public static Node commentReplyCountProperty() { return RdfUtils.uri(GH_NS + "commentReplyCount"); }
 
     public static Node hasCommentReplyProperty() { return RdfUtils.uri(GH_NS + "hasCommentReply"); }
 
@@ -221,9 +217,6 @@ public final class RdfGithubIssueUtils {
         return Triple.create(RdfUtils.uri(issueUri), hasReviewProperty(), RdfUtils.uri(reviewUri));
     }
 
-    public static Triple createIssueReviewCountProperty(String issueUri, long count) {
-        return Triple.create(RdfUtils.uri(issueUri), reviewCountProperty(), RdfUtils.nonNegativeIntegerLiteral(count));
-    }
 
     public static Triple createIssueReviewContainerProperty(String issueUri, String containerUri) {
         return Triple.create(RdfUtils.uri(issueUri), reviewContainerProperty(), RdfUtils.uri(containerUri));
@@ -262,9 +255,6 @@ public final class RdfGithubIssueUtils {
         return Triple.create(RdfUtils.uri(reviewUri), authorAssociationProperty(), RdfUtils.stringLiteral(association));
     }
 
-    public static Triple createReviewCommentCountProperty(String reviewUri, long count) {
-        return Triple.create(RdfUtils.uri(reviewUri), reviewCommentCountProperty(), RdfUtils.nonNegativeIntegerLiteral(count));
-    }
 
     public static Triple createReviewHasCommentProperty(String reviewUri, String commentUri) {
         return Triple.create(RdfUtils.uri(reviewUri), hasReviewCommentProperty(), RdfUtils.uri(commentUri));
@@ -275,9 +265,6 @@ public final class RdfGithubIssueUtils {
         return Triple.create(RdfUtils.uri(issueUri), hasCommentProperty(), RdfUtils.uri(commentUri));
     }
 
-    public static Triple createIssueCommentCountProperty(String issueUri, long count) {
-        return Triple.create(RdfUtils.uri(issueUri), commentCountProperty(), RdfUtils.nonNegativeIntegerLiteral(count));
-    }
 
     public static Triple createIssueDiscussionProperty(String issueUri, String discussionUri) {
         return Triple.create(RdfUtils.uri(issueUri), discussionProperty(), RdfUtils.uri(discussionUri));
@@ -308,9 +295,6 @@ public final class RdfGithubIssueUtils {
         return Triple.create(RdfUtils.uri(commentUri), isRootCommentProperty(), RdfUtils.stringLiteral(Boolean.toString(isRoot)));
     }
 
-    public static Triple createCommentReplyCountProperty(String commentUri, long count) {
-        return Triple.create(RdfUtils.uri(commentUri), commentReplyCountProperty(), RdfUtils.nonNegativeIntegerLiteral(count));
-    }
 
     public static Triple createHasCommentReplyProperty(String commentUri, String replyUri) {
         return Triple.create(RdfUtils.uri(commentUri), hasCommentReplyProperty(), RdfUtils.uri(replyUri));


### PR DESCRIPTION
## Summary
- represent review and comment collections as direct lists of URIs
- drop all count related triples and unused utility functions

## Testing
- `sh mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685fe3b87f98832b92a424b89598b8a9