### PR TITLE
Implement review comment RDF aggregation

### DIFF
--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
@@ -82,6 +82,7 @@ import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfCommitUtils;
 import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGitCommitUserUtils;
 import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGithubIssueReviewUtils;
 import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGithubIssueUtils;
+import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGithubIssueCommentUtils;
 import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
 
@@ -891,7 +892,86 @@ public class GithubRdfConversionTransactionService {
 
                                 List<GHPullRequestReviewComment> reviewComments = review.listReviewComments().toList();
                                 String commentListUri = reviewUri + "#comments";
-                                // COMMENTS OF THE REVIEW
+
+                                writer.triple(RdfGithubIssueReviewUtils.createDiscussionProperty(reviewUri, commentListUri));
+                                writer.triple(RdfGithubIssueCommentUtils.createReviewCommentContainerRdfTypeProperty(commentListUri));
+
+                                int reviewCommentCount = reviewComments.size();
+                                int rootCommentCount = 0;
+                                Set<Long> threadIds = new HashSet<>();
+                                Map<Long, List<Long>> repliesByParent = new HashMap<>();
+                                LocalDateTime firstCommentAt = null;
+                                LocalDateTime lastCommentAt = null;
+
+                                for (GHPullRequestReviewComment c : reviewComments) {
+                                    LocalDateTime created = localDateTimeFrom(c.getCreatedAt());
+                                    LocalDateTime updated = c.getUpdatedAt() != null ? localDateTimeFrom(c.getUpdatedAt()) : created;
+                                    if (firstCommentAt == null || created.isBefore(firstCommentAt)) {
+                                        firstCommentAt = created;
+                                    }
+                                    if (lastCommentAt == null || updated.isAfter(lastCommentAt)) {
+                                        lastCommentAt = updated;
+                                    }
+
+                                    Long threadId = c.getPullRequestReviewThreadId();
+                                    if (threadId != null) {
+                                        threadIds.add(threadId);
+                                    }
+
+                                    Long parentId = c.getInReplyToId();
+                                    if (parentId == null) {
+                                        rootCommentCount++;
+                                    } else {
+                                        repliesByParent.computeIfAbsent(parentId, k -> new ArrayList<>()).add(c.getId());
+                                    }
+                                }
+
+                                writer.triple(RdfGithubIssueReviewUtils.createReviewCommentCountProperty(reviewUri, reviewCommentCount));
+                                writer.triple(RdfGithubIssueReviewUtils.createRootCommentCountProperty(reviewUri, rootCommentCount));
+                                writer.triple(RdfGithubIssueReviewUtils.createThreadCountProperty(reviewUri, threadIds.size()));
+                                if (firstCommentAt != null) {
+                                    writer.triple(RdfGithubIssueReviewUtils.createFirstCommentAtProperty(reviewUri, firstCommentAt));
+                                }
+                                if (lastCommentAt != null) {
+                                    writer.triple(RdfGithubIssueReviewUtils.createLastCommentAtProperty(reviewUri, lastCommentAt));
+                                    writer.triple(RdfGithubIssueReviewUtils.createLastActivityProperty(reviewUri, lastCommentAt));
+                                }
+
+                                for (GHPullRequestReviewComment c : reviewComments) {
+                                    long cid = c.getId();
+                                    String commentUri = commentListUri + "/" + cid;
+
+                                    writer.triple(RdfGithubIssueReviewUtils.createReviewCommentsProperty(reviewUri, commentUri));
+                                    writer.triple(RdfGithubIssueCommentUtils.createReviewCommentRdfTypeProperty(commentUri));
+                                    writer.triple(RdfGithubIssueCommentUtils.createCommentIdentifierProperty(commentUri, cid));
+                                    writer.triple(RdfGithubIssueCommentUtils.createReviewCommentOfProperty(commentUri, reviewUri));
+                                    if (c.getBody() != null && !c.getBody().isEmpty()) {
+                                        writer.triple(RdfGithubIssueCommentUtils.createCommentDescriptionProperty(commentUri, c.getBody()));
+                                    }
+                                    if (c.getUser() != null) {
+                                        writer.triple(RdfGithubIssueCommentUtils.createCommentAuthorProperty(commentUri, c.getUser().getHtmlUrl().toString()));
+                                    }
+                                    if (c.getCreatedAt() != null) {
+                                        writer.triple(RdfGithubIssueCommentUtils.createCommentCreatedAtProperty(commentUri, localDateTimeFrom(c.getCreatedAt())));
+                                    }
+
+                                    Long parentId = c.getInReplyToId();
+                                    if (parentId == null) {
+                                        writer.triple(RdfGithubIssueCommentUtils.createCommentIsRootProperty(commentUri, true));
+                                        writer.triple(RdfGithubIssueReviewUtils.createRootCommentsProperty(reviewUri, commentUri));
+                                    } else {
+                                        writer.triple(RdfGithubIssueCommentUtils.createCommentIsRootProperty(commentUri, false));
+                                        String parentUri = commentListUri + "/" + parentId;
+                                        writer.triple(RdfGithubIssueCommentUtils.createReviewCommentReplyToProperty(commentUri, parentUri));
+                                    }
+
+                                    List<Long> replies = repliesByParent.getOrDefault(cid, List.of());
+                                    writer.triple(RdfGithubIssueCommentUtils.createCommentReplyCountProperty(commentUri, replies.size()));
+                                    for (Long rid : replies) {
+                                        String replyUri = commentListUri + "/" + rid;
+                                        writer.triple(RdfGithubIssueCommentUtils.createHasCommentReplyProperty(commentUri, replyUri));
+                                    }
+                                }
                             }
                         }
 

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueReviewUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueReviewUtils.java
@@ -23,6 +23,14 @@ public final class RdfGithubIssueReviewUtils {
     public static Node commitIdProperty() { return uri(GH_NS + "commitId"); }
     public static Node discussionProperty() { return uri(GH_NS + "discussion"); }
     public static Node commentProperty() { return uri(GH_NS + "comment"); }
+    public static Node reviewCommentsProperty() { return uri(GH_NS + "reviewComments"); }
+    public static Node rootCommentsProperty() { return uri(GH_NS + "rootComments"); }
+    public static Node reviewCommentCountProperty() { return uri(GH_NS + "reviewCommentCount"); }
+    public static Node rootCommentCountProperty() { return uri(GH_NS + "rootCommentCount"); }
+    public static Node threadCountProperty() { return uri(GH_NS + "threadCount"); }
+    public static Node firstCommentAtProperty() { return uri(GH_NS + "firstCommentAt"); }
+    public static Node lastCommentAtProperty() { return uri(GH_NS + "lastCommentAt"); }
+    public static Node lastActivityProperty() { return uri(GH_NS + "lastActivity"); }
 
     public static Triple createReviewIdentifierProperty(String reviewUri, long id) {
         return Triple.create(uri(reviewUri), identifierProperty(), RdfUtils.longLiteral(id));
@@ -59,6 +67,39 @@ public final class RdfGithubIssueReviewUtils {
 
     public static Triple createReviewCommentProperty(String reviewUri, String commentUri) {
         return Triple.create(uri(reviewUri), commentProperty(), uri(commentUri));
+    }
+
+
+    public static Triple createReviewCommentsProperty(String reviewUri, String commentUri) {
+        return Triple.create(uri(reviewUri), reviewCommentsProperty(), uri(commentUri));
+    }
+
+    public static Triple createRootCommentsProperty(String reviewUri, String commentUri) {
+        return Triple.create(uri(reviewUri), rootCommentsProperty(), uri(commentUri));
+    }
+
+    public static Triple createReviewCommentCountProperty(String reviewUri, long count) {
+        return Triple.create(uri(reviewUri), reviewCommentCountProperty(), RdfUtils.nonNegativeIntegerLiteral(count));
+    }
+
+    public static Triple createRootCommentCountProperty(String reviewUri, long count) {
+        return Triple.create(uri(reviewUri), rootCommentCountProperty(), RdfUtils.nonNegativeIntegerLiteral(count));
+    }
+
+    public static Triple createThreadCountProperty(String reviewUri, long count) {
+        return Triple.create(uri(reviewUri), threadCountProperty(), RdfUtils.nonNegativeIntegerLiteral(count));
+    }
+
+    public static Triple createFirstCommentAtProperty(String reviewUri, LocalDateTime dateTime) {
+        return Triple.create(uri(reviewUri), firstCommentAtProperty(), RdfUtils.dateTimeLiteral(dateTime));
+    }
+
+    public static Triple createLastCommentAtProperty(String reviewUri, LocalDateTime dateTime) {
+        return Triple.create(uri(reviewUri), lastCommentAtProperty(), RdfUtils.dateTimeLiteral(dateTime));
+    }
+
+    public static Triple createLastActivityProperty(String reviewUri, LocalDateTime dateTime) {
+        return Triple.create(uri(reviewUri), lastActivityProperty(), RdfUtils.dateTimeLiteral(dateTime));
     }
 
 


### PR DESCRIPTION
## Summary
- extend `RdfGithubIssueReviewUtils` with properties and triple helpers for review comments
- implement review comment extraction and aggregation in `GithubRdfConversionTransactionService`

## Testing
- `mvn -q -DskipTests compile` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686002940994832ba2b7b3726153df53