### PR TITLE
Add workflow run RDF integration

### DIFF
--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.time.StopWatch;
 import org.apache.jena.graph.Node;
@@ -62,6 +63,8 @@ import org.kohsuke.github.GHPullRequestReview;
 import org.kohsuke.github.GHPullRequestReviewComment;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
+import org.kohsuke.github.GHWorkflowJob;
+import org.kohsuke.github.GHWorkflowRun;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -83,6 +86,8 @@ import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGitCommitUserUtils;
 import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGithubIssueDiscussionUtils;
 import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGithubIssueReviewUtils;
 import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGithubIssueUtils;
+import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGithubWorkflowJobUtils;
+import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGithubWorkflowUtils;
 import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
 
@@ -254,6 +259,85 @@ public class GithubRdfConversionTransactionService {
             log.warn("Error while writing merge info for issue {}: {}", issueUri, e.getMessage());
         }
         // TODO: Add addional merge information if available
+    }
+
+    private void writeWorkflowRunInfo(GHPullRequest pr, StreamRDF writer, String issueUri) {
+        if (pr == null || !pr.isMerged()) {
+            return;
+        }
+
+        try {
+            GHRepository repo = pr.getRepository();
+            String mergeSha = pr.getMergeCommitSha();
+            if (repo == null || mergeSha == null) {
+                return;
+            }
+
+            List<GHWorkflowRun> runs = repo.queryWorkflowRuns()
+                    .branch(pr.getBase().getRef())
+                    .list()
+                    .toList()
+                    .stream()
+                    .filter(run -> mergeSha.equalsIgnoreCase(run.getHeadSha()))
+                    .collect(Collectors.toList());
+
+            for (GHWorkflowRun run : runs) {
+                String runUri = run.getHtmlUrl().toString();
+                writer.triple(RdfGithubWorkflowUtils.createWorkflowRunProperty(issueUri, runUri));
+                writer.triple(RdfGithubWorkflowUtils.createWorkflowRunRdfTypeProperty(runUri));
+                writer.triple(RdfGithubWorkflowUtils.createWorkflowRunIdProperty(runUri, run.getId()));
+
+                if (run.getName() != null) {
+                    writer.triple(RdfGithubWorkflowUtils.createWorkflowNameProperty(runUri, run.getName()));
+                }
+                if (run.getStatus() != null) {
+                    writer.triple(RdfGithubWorkflowUtils.createWorkflowStatusProperty(runUri, run.getStatus()));
+                }
+                if (run.getConclusion() != null) {
+                    writer.triple(RdfGithubWorkflowUtils.createWorkflowConclusionProperty(runUri, run.getConclusion()));
+                }
+                if (run.getEvent() != null) {
+                    writer.triple(RdfGithubWorkflowUtils.createWorkflowEventProperty(runUri, run.getEvent()));
+                }
+
+                writer.triple(RdfGithubWorkflowUtils.createWorkflowRunNumberProperty(runUri, run.getRunNumber()));
+                writer.triple(RdfGithubWorkflowUtils.createWorkflowCommitShaProperty(runUri, mergeSha));
+                if (run.getHtmlUrl() != null) {
+                    writer.triple(RdfGithubWorkflowUtils.createWorkflowHtmlUrlProperty(runUri, run.getHtmlUrl().toString()));
+                }
+                if (run.getCreatedAt() != null) {
+                    writer.triple(RdfGithubWorkflowUtils.createWorkflowCreatedAtProperty(runUri, localDateTimeFrom(run.getCreatedAt())));
+                }
+                if (run.getUpdatedAt() != null) {
+                    writer.triple(RdfGithubWorkflowUtils.createWorkflowUpdatedAtProperty(runUri, localDateTimeFrom(run.getUpdatedAt())));
+                }
+
+                for (GHWorkflowJob job : run.listJobs().toList()) {
+                    String jobUri = runUri + "/jobs/" + job.getId();
+                    writer.triple(RdfGithubWorkflowUtils.createWorkflowJobProperty(runUri, jobUri));
+                    writer.triple(RdfGithubWorkflowJobUtils.createWorkflowJobRdfTypeProperty(jobUri));
+                    writer.triple(RdfGithubWorkflowJobUtils.createWorkflowJobIdProperty(jobUri, job.getId()));
+                    if (job.getName() != null) {
+                        writer.triple(RdfGithubWorkflowJobUtils.createWorkflowJobNameProperty(jobUri, job.getName()));
+                    }
+                    if (job.getStatus() != null) {
+                        writer.triple(RdfGithubWorkflowJobUtils.createWorkflowJobStatusProperty(jobUri, job.getStatus()));
+                    }
+                    if (job.getConclusion() != null) {
+                        writer.triple(RdfGithubWorkflowJobUtils.createWorkflowJobConclusionProperty(jobUri, job.getConclusion()));
+                    }
+                    if (job.getStartedAt() != null) {
+                        writer.triple(RdfGithubWorkflowJobUtils.createWorkflowJobStartedAtProperty(jobUri, localDateTimeFrom(job.getStartedAt())));
+                    }
+                    if (job.getCompletedAt() != null) {
+                        writer.triple(RdfGithubWorkflowJobUtils.createWorkflowJobCompletedAtProperty(jobUri, localDateTimeFrom(job.getCompletedAt())));
+                    }
+                }
+            }
+
+        } catch (IOException e) {
+            log.warn("Error while writing workflow run info for issue {}: {}", issueUri, e.getMessage());
+        }
     }
 
     private Git performGitClone(String ownerName, String repositoryName, File gitWorkingDirectory) throws GitAPIException {
@@ -862,6 +946,7 @@ public class GithubRdfConversionTransactionService {
                             if (ghIssue.isPullRequest()) {
                                 GHPullRequest pullRequest = githubRepositoryHandle.getPullRequest(issueNumber);
                                 writeMergeInfo(ghIssue, pullRequest, writer, issueUri);
+                                writeWorkflowRunInfo(pullRequest, writer, issueUri);
                             }
                         }
 

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubWorkflowJobUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubWorkflowJobUtils.java
@@ -1,0 +1,57 @@
+package de.leipzig.htwk.gitrdf.worker.utils.rdf;
+
+import static de.leipzig.htwk.gitrdf.worker.service.impl.GithubRdfConversionTransactionService.PLATFORM_GITHUB_NAMESPACE;
+
+import java.time.LocalDateTime;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.Triple;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class RdfGithubWorkflowJobUtils {
+
+    private static final String GH_NS = PLATFORM_GITHUB_NAMESPACE + ":";
+
+    public static Node rdfTypeProperty() {
+        return RdfUtils.uri("rdf:type");
+    }
+
+    public static Node identifierProperty() { return RdfUtils.uri(GH_NS + "workflowJobId"); }
+    public static Node nameProperty() { return RdfUtils.uri(GH_NS + "workflowJobName"); }
+    public static Node statusProperty() { return RdfUtils.uri(GH_NS + "workflowJobStatus"); }
+    public static Node conclusionProperty() { return RdfUtils.uri(GH_NS + "workflowJobConclusion"); }
+    public static Node startedAtProperty() { return RdfUtils.uri(GH_NS + "workflowJobStartedAt"); }
+    public static Node completedAtProperty() { return RdfUtils.uri(GH_NS + "workflowJobCompletedAt"); }
+
+    // Triple creation
+    public static Triple createWorkflowJobRdfTypeProperty(String jobUri) {
+        return Triple.create(RdfUtils.uri(jobUri), rdfTypeProperty(), RdfUtils.uri("github:WorkflowJob"));
+    }
+
+    public static Triple createWorkflowJobIdProperty(String jobUri, long id) {
+        return Triple.create(RdfUtils.uri(jobUri), identifierProperty(), RdfUtils.longLiteral(id));
+    }
+
+    public static Triple createWorkflowJobNameProperty(String jobUri, String name) {
+        return Triple.create(RdfUtils.uri(jobUri), nameProperty(), RdfUtils.stringLiteral(name));
+    }
+
+    public static Triple createWorkflowJobStatusProperty(String jobUri, String status) {
+        return Triple.create(RdfUtils.uri(jobUri), statusProperty(), RdfUtils.uri(GH_NS + status.toLowerCase()));
+    }
+
+    public static Triple createWorkflowJobConclusionProperty(String jobUri, String conclusion) {
+        return Triple.create(RdfUtils.uri(jobUri), conclusionProperty(), RdfUtils.uri(GH_NS + conclusion.toLowerCase()));
+    }
+
+    public static Triple createWorkflowJobStartedAtProperty(String jobUri, LocalDateTime started) {
+        return Triple.create(RdfUtils.uri(jobUri), startedAtProperty(), RdfUtils.dateTimeLiteral(started));
+    }
+
+    public static Triple createWorkflowJobCompletedAtProperty(String jobUri, LocalDateTime completed) {
+        return Triple.create(RdfUtils.uri(jobUri), completedAtProperty(), RdfUtils.dateTimeLiteral(completed));
+    }
+}

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubWorkflowUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubWorkflowUtils.java
@@ -1,0 +1,87 @@
+package de.leipzig.htwk.gitrdf.worker.utils.rdf;
+
+import static de.leipzig.htwk.gitrdf.worker.service.impl.GithubRdfConversionTransactionService.PLATFORM_GITHUB_NAMESPACE;
+
+import java.time.LocalDateTime;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.Triple;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class RdfGithubWorkflowUtils {
+
+    private static final String GH_NS = PLATFORM_GITHUB_NAMESPACE + ":";
+
+    public static Node rdfTypeProperty() {
+        return RdfUtils.uri("rdf:type");
+    }
+
+    public static Node workflowRunProperty() { return RdfUtils.uri(GH_NS + "workflowRun"); }
+    public static Node identifierProperty() { return RdfUtils.uri(GH_NS + "workflowRunId"); }
+    public static Node nameProperty() { return RdfUtils.uri(GH_NS + "workflowName"); }
+    public static Node statusProperty() { return RdfUtils.uri(GH_NS + "workflowStatus"); }
+    public static Node conclusionProperty() { return RdfUtils.uri(GH_NS + "workflowConclusion"); }
+    public static Node eventProperty() { return RdfUtils.uri(GH_NS + "workflowEvent"); }
+    public static Node runNumberProperty() { return RdfUtils.uri(GH_NS + "workflowRunNumber"); }
+    public static Node commitShaProperty() { return RdfUtils.uri(GH_NS + "workflowCommitSha"); }
+    public static Node htmlUrlProperty() { return RdfUtils.uri(GH_NS + "workflowHtmlUrl"); }
+    public static Node createdAtProperty() { return RdfUtils.uri(GH_NS + "workflowCreatedAt"); }
+    public static Node updatedAtProperty() { return RdfUtils.uri(GH_NS + "workflowUpdatedAt"); }
+    public static Node jobProperty() { return RdfUtils.uri(GH_NS + "workflowJob"); }
+
+    // Triple creation
+    public static Triple createWorkflowRunProperty(String issueUri, String runUri) {
+        return Triple.create(RdfUtils.uri(issueUri), workflowRunProperty(), RdfUtils.uri(runUri));
+    }
+
+    public static Triple createWorkflowRunRdfTypeProperty(String runUri) {
+        return Triple.create(RdfUtils.uri(runUri), rdfTypeProperty(), RdfUtils.uri("github:WorkflowRun"));
+    }
+
+    public static Triple createWorkflowRunIdProperty(String runUri, long id) {
+        return Triple.create(RdfUtils.uri(runUri), identifierProperty(), RdfUtils.longLiteral(id));
+    }
+
+    public static Triple createWorkflowNameProperty(String runUri, String name) {
+        return Triple.create(RdfUtils.uri(runUri), nameProperty(), RdfUtils.stringLiteral(name));
+    }
+
+    public static Triple createWorkflowStatusProperty(String runUri, String status) {
+        return Triple.create(RdfUtils.uri(runUri), statusProperty(), RdfUtils.uri(GH_NS + status.toLowerCase()));
+    }
+
+    public static Triple createWorkflowConclusionProperty(String runUri, String conclusion) {
+        return Triple.create(RdfUtils.uri(runUri), conclusionProperty(), RdfUtils.uri(GH_NS + conclusion.toLowerCase()));
+    }
+
+    public static Triple createWorkflowEventProperty(String runUri, String event) {
+        return Triple.create(RdfUtils.uri(runUri), eventProperty(), RdfUtils.uri(GH_NS + event.toLowerCase()));
+    }
+
+    public static Triple createWorkflowRunNumberProperty(String runUri, int runNumber) {
+        return Triple.create(RdfUtils.uri(runUri), runNumberProperty(), RdfUtils.integerLiteral(runNumber));
+    }
+
+    public static Triple createWorkflowCommitShaProperty(String runUri, String sha) {
+        return Triple.create(RdfUtils.uri(runUri), commitShaProperty(), RdfUtils.stringLiteral(sha));
+    }
+
+    public static Triple createWorkflowHtmlUrlProperty(String runUri, String url) {
+        return Triple.create(RdfUtils.uri(runUri), htmlUrlProperty(), RdfUtils.uri(url));
+    }
+
+    public static Triple createWorkflowCreatedAtProperty(String runUri, LocalDateTime created) {
+        return Triple.create(RdfUtils.uri(runUri), createdAtProperty(), RdfUtils.dateTimeLiteral(created));
+    }
+
+    public static Triple createWorkflowUpdatedAtProperty(String runUri, LocalDateTime updated) {
+        return Triple.create(RdfUtils.uri(runUri), updatedAtProperty(), RdfUtils.dateTimeLiteral(updated));
+    }
+
+    public static Triple createWorkflowJobProperty(String runUri, String jobUri) {
+        return Triple.create(RdfUtils.uri(runUri), jobProperty(), RdfUtils.uri(jobUri));
+    }
+}


### PR DESCRIPTION
## Summary
- add utilities to convert GitHub workflow runs and jobs to RDF
- extend `GithubRdfConversionTransactionService` to record workflow run info for merged pull requests
- filter workflow runs by merge commit SHA instead of unsupported query option

## Testing
- `bash mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6860507ab240832baae353ede6b2af87