### PR TITLE
Add RDF workflow step support

### DIFF
--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
@@ -66,6 +66,7 @@ import org.kohsuke.github.GHPullRequestReviewComment;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GHUser;
 import org.kohsuke.github.GHWorkflowJob;
+import org.kohsuke.github.GHWorkflowJobStep;
 import org.kohsuke.github.GHWorkflowRun;
 import org.kohsuke.github.GitHub;
 import org.kohsuke.github.PagedIterable;
@@ -91,6 +92,7 @@ import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGithubIssueDiscussionUtils;
 import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGithubIssueReviewUtils;
 import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGithubIssueUtils;
 import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGithubWorkflowJobUtils;
+import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGithubWorkflowStepUtils;
 import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGithubWorkflowUtils;
 import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
@@ -485,6 +487,40 @@ private void writeJobProperties(GHWorkflowJob job, StreamRDF writer, String runU
     }
     if (job.getCompletedAt() != null) {
         writer.triple(RdfGithubWorkflowJobUtils.createWorkflowJobCompletedAtProperty(jobUri, localDateTimeFrom(job.getCompletedAt())));
+    }
+
+    if (job.getSteps() != null) {
+        List<GHWorkflowJobStep> steps = job.getSteps();
+        for (int i = 0; i < steps.size(); i++) {
+            GHWorkflowJobStep step = steps.get(i);
+            String stepUri = jobUri + "/steps/" + step.getNumber();
+
+            writer.triple(RdfGithubWorkflowJobUtils.createWorkflowJobStepProperty(jobUri, stepUri));
+            writer.triple(RdfGithubWorkflowStepUtils.createWorkflowStepRdfTypeProperty(stepUri));
+            writer.triple(RdfGithubWorkflowStepUtils.createWorkflowStepNumberProperty(stepUri, step.getNumber()));
+
+            if (step.getName() != null) {
+                writer.triple(RdfGithubWorkflowStepUtils.createWorkflowStepNameProperty(stepUri, step.getName()));
+            }
+            if (step.getStatus() != null) {
+                writer.triple(RdfGithubWorkflowStepUtils.createWorkflowStepStatusProperty(stepUri, step.getStatus()));
+            }
+            if (step.getConclusion() != null) {
+                writer.triple(RdfGithubWorkflowStepUtils.createWorkflowStepConclusionProperty(stepUri, step.getConclusion()));
+            }
+            if (step.getStartedAt() != null) {
+                writer.triple(RdfGithubWorkflowStepUtils.createWorkflowStepStartedAtProperty(stepUri, localDateTimeFrom(step.getStartedAt())));
+            }
+            if (step.getCompletedAt() != null) {
+                writer.triple(RdfGithubWorkflowStepUtils.createWorkflowStepCompletedAtProperty(stepUri, localDateTimeFrom(step.getCompletedAt())));
+            }
+
+            if (i < steps.size() - 1) {
+                GHWorkflowJobStep nextStep = steps.get(i + 1);
+                String nextStepUri = jobUri + "/steps/" + nextStep.getNumber();
+                writer.triple(RdfGithubWorkflowStepUtils.createWorkflowNextStepProperty(stepUri, nextStepUri));
+            }
+        }
     }
 }
 

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubWorkflowJobUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubWorkflowJobUtils.java
@@ -27,6 +27,7 @@ public final class RdfGithubWorkflowJobUtils {
     public static Node conclusionProperty() { return RdfUtils.uri(GH_NS + "workflowJobConclusion"); }
     public static Node startedAtProperty() { return RdfUtils.uri(GH_NS + "workflowJobStartedAt"); }
     public static Node completedAtProperty() { return RdfUtils.uri(GH_NS + "workflowJobCompletedAt"); }
+    public static Node stepProperty() { return RdfUtils.uri(GH_NS + "workflowStep"); }
 
     // Triple creation
     public static Triple createWorkflowJobRdfTypeProperty(String jobUri) {
@@ -55,5 +56,9 @@ public final class RdfGithubWorkflowJobUtils {
 
     public static Triple createWorkflowJobCompletedAtProperty(String jobUri, LocalDateTime completed) {
         return Triple.create(RdfUtils.uri(jobUri), completedAtProperty(), RdfUtils.dateTimeLiteral(completed));
+    }
+
+    public static Triple createWorkflowJobStepProperty(String jobUri, String stepUri) {
+        return Triple.create(RdfUtils.uri(jobUri), stepProperty(), RdfUtils.uri(stepUri));
     }
 }

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubWorkflowStepUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubWorkflowStepUtils.java
@@ -1,0 +1,63 @@
+package de.leipzig.htwk.gitrdf.worker.utils.rdf;
+
+import static de.leipzig.htwk.gitrdf.worker.service.impl.GithubRdfConversionTransactionService.PLATFORM_GITHUB_NAMESPACE;
+
+import java.time.LocalDateTime;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.Triple;
+import org.kohsuke.github.GHWorkflowRun;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class RdfGithubWorkflowStepUtils {
+
+    private static final String GH_NS = PLATFORM_GITHUB_NAMESPACE + ":";
+
+    public static Node rdfTypeProperty() {
+        return RdfUtils.uri("rdf:type");
+    }
+
+    public static Node numberProperty() { return RdfUtils.uri(GH_NS + "workflowStepNumber"); }
+    public static Node nameProperty() { return RdfUtils.uri(GH_NS + "workflowStepName"); }
+    public static Node statusProperty() { return RdfUtils.uri(GH_NS + "workflowStepStatus"); }
+    public static Node conclusionProperty() { return RdfUtils.uri(GH_NS + "workflowStepConclusion"); }
+    public static Node startedAtProperty() { return RdfUtils.uri(GH_NS + "workflowStepStartedAt"); }
+    public static Node completedAtProperty() { return RdfUtils.uri(GH_NS + "workflowStepCompletedAt"); }
+    public static Node nextStepProperty() { return RdfUtils.uri(GH_NS + "workflowNextStep"); }
+
+    // Triple creation
+    public static Triple createWorkflowStepRdfTypeProperty(String stepUri) {
+        return Triple.create(RdfUtils.uri(stepUri), rdfTypeProperty(), RdfUtils.uri("github:WorkflowStep"));
+    }
+
+    public static Triple createWorkflowStepNumberProperty(String stepUri, int number) {
+        return Triple.create(RdfUtils.uri(stepUri), numberProperty(), RdfUtils.integerLiteral(number));
+    }
+
+    public static Triple createWorkflowStepNameProperty(String stepUri, String name) {
+        return Triple.create(RdfUtils.uri(stepUri), nameProperty(), RdfUtils.stringLiteral(name));
+    }
+
+    public static Triple createWorkflowStepStatusProperty(String stepUri, GHWorkflowRun.Status status) {
+        return Triple.create(RdfUtils.uri(stepUri), statusProperty(), RdfUtils.uri(GH_NS + status));
+    }
+
+    public static Triple createWorkflowStepConclusionProperty(String stepUri, GHWorkflowRun.Conclusion conclusion) {
+        return Triple.create(RdfUtils.uri(stepUri), conclusionProperty(), RdfUtils.uri(GH_NS + conclusion));
+    }
+
+    public static Triple createWorkflowStepStartedAtProperty(String stepUri, LocalDateTime started) {
+        return Triple.create(RdfUtils.uri(stepUri), startedAtProperty(), RdfUtils.dateTimeLiteral(started));
+    }
+
+    public static Triple createWorkflowStepCompletedAtProperty(String stepUri, LocalDateTime completed) {
+        return Triple.create(RdfUtils.uri(stepUri), completedAtProperty(), RdfUtils.dateTimeLiteral(completed));
+    }
+
+    public static Triple createWorkflowNextStepProperty(String stepUri, String nextStepUri) {
+        return Triple.create(RdfUtils.uri(stepUri), nextStepProperty(), RdfUtils.uri(nextStepUri));
+    }
+}


### PR DESCRIPTION
## Summary
- add new RDF utilities for representing workflow steps
- link jobs to step data and record step order
- record step details while processing workflow jobs

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6860635cc0b0832ba8390947446a0753