### PR TITLE
Add Turtle tidy utility and integrate in RDF conversion

### DIFF
--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GitRdfConversionTransactionService.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GitRdfConversionTransactionService.java
@@ -18,6 +18,7 @@ import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.hibernate.engine.jdbc.BlobProxy;
+import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfTurtleTidier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -135,6 +136,8 @@ public class GitRdfConversionTransactionService {
             }
 
         }
+
+        RdfTurtleTidier.tidyFile(tempFile);
 
         BufferedInputStream bufferedInputStream = new BufferedInputStream(new FileInputStream(tempFile));
 

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
@@ -23,6 +23,8 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfTurtleTidier;
+
 import org.apache.commons.lang3.time.StopWatch;
 import org.apache.jena.graph.Node;
 import org.apache.jena.rdf.model.Resource;
@@ -1362,6 +1364,8 @@ private boolean shouldIncludeJobDetails(GHWorkflowRun run) {
         }
 
         log.info("Finished overall processing. Start to load rdf file into postgres blob storage");
+
+        RdfTurtleTidier.tidyFile(rdfTempFile);
 
         BufferedInputStream bufferedInputStream = new BufferedInputStream(new FileInputStream(rdfTempFile));
 

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfTurtleTidier.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfTurtleTidier.java
@@ -1,0 +1,30 @@
+package de.leipzig.htwk.gitrdf.worker.utils.rdf;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RDFFormat;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class RdfTurtleTidier {
+
+    public static void tidyFile(File file) throws IOException {
+        Model model = ModelFactory.createDefaultModel();
+        try (InputStream in = new FileInputStream(file)) {
+            RDFDataMgr.read(model, in, Lang.TURTLE);
+        }
+        try (OutputStream out = new FileOutputStream(file)) {
+            RDFDataMgr.write(out, model, RDFFormat.TURTLE_PRETTY);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `RdfTurtleTidier` utility for pretty formatting Turtle files
- tidy temporary RDF files in `GitRdfConversionTransactionService`
- tidy temporary RDF files in `GithubRdfConversionTransactionService`

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686066fb8bf4832b803e4ca00e09f25b