### PR TITLE
Add commit issue reference handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# RDF Predicates
+
+This project exposes several RDF predicates for representing Git and GitHub data.
+
+* `github:issue` – links a commit to a referenced GitHub issue detected in the commit message.
+

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
@@ -559,6 +559,8 @@ public class GithubRdfConversionTransactionService {
                             calculateCommitMessage(writer, commitUri, commit);
                         }
 
+                        calculateCommitIssues(writer, commitUri, commit.getFullMessage(), owner, repositoryName);
+
                         // Branch
                         // TODO: better way to handle merges? (so commit could have multiple branches)
                         if (gitCommitRepositoryFilter.isEnableCommitBranch()) {
@@ -1131,6 +1133,13 @@ public class GithubRdfConversionTransactionService {
 
     }
 
+    private void calculateCommitIssues(StreamRDF writer, String commitUri, String message, String owner, String repositoryName) {
+        for (String number : RdfCommitUtils.extractIssueNumbers(message)) {
+            String issueUri = getGithubIssueUri(owner, repositoryName, number);
+            writer.triple(RdfCommitUtils.createCommitIssueProperty(commitUri, issueUri));
+        }
+    }
+
     private void calculateCommitterEmail(StreamRDF writer, String commitUri, PersonIdent committerIdent) {
 
         if (committerIdent == null) {
@@ -1333,6 +1342,14 @@ public class GithubRdfConversionTransactionService {
 
     private String getGithubCommitUri(String owner, String repository, String commitHash) {
         return getGithubCommitBaseUri(owner, repository) + commitHash;
+    }
+
+    private String getGithubIssueBaseUri(String owner, String repository) {
+        return "https://github.com/" + owner + "/" + repository + "/issues/";
+    }
+
+    private String getGithubIssueUri(String owner, String repository, String issueNumber) {
+        return getGithubIssueBaseUri(owner, repository) + issueNumber;
     }
 
     public String getGithubUserUri(String userName) {

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfCommitUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfCommitUtils.java
@@ -9,6 +9,11 @@ import static de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfUtils.stringLiteral;
 import static de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfUtils.uri;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
@@ -114,6 +119,13 @@ public final class RdfCommitUtils {
 
     public static Node commitGitHubUserProperty() {
         return uri(GH_NS + "user");
+    }
+
+    /**
+     * Links a commit to a referenced GitHub issue.
+     */
+    public static Node commitIssueProperty() {
+        return uri(GH_NS + "issue");
     }
     public static Node tagResource() {
         return uri(NS + "tag");
@@ -281,6 +293,10 @@ public final class RdfCommitUtils {
         //return Triple.create(uri(commitUri), commitGitHubUserProperty(), stringLiteral(commiterGitHubUser));
         return Triple.create(uri(commitUri), commitGitHubUserProperty(), uri(commiterGitHubUser));
     }
+
+    public static Triple createCommitIssueProperty(String commitUri, String issueUri) {
+        return Triple.create(uri(commitUri), commitIssueProperty(), uri(issueUri));
+    }
     public static Triple createCommitResource(String commitUri, Node commitNode) {
         return Triple.create(uri(commitUri), commitResource(), commitNode);
     }
@@ -343,6 +359,23 @@ public final class RdfCommitUtils {
 
     public static Triple createCommitTagProperty(String commitUri, String tagName) {
         return Triple.create(uri(commitUri), commitTagNameProperty(), stringLiteral(tagName));
+    }
+
+    /**
+     * Extract referenced issue numbers from a commit message.
+     * Supports patterns like "Fixes #123" or "#123".
+     */
+    public static Set<String> extractIssueNumbers(String commitMessage) {
+        if (commitMessage == null) {
+            return Collections.emptySet();
+        }
+        Set<String> result = new LinkedHashSet<>();
+        Pattern p = Pattern.compile("(?i)(?:fix(?:es)?|close(?:s)?|resolve(?:s)?|)\\s*#(\\d+)");
+        Matcher m = p.matcher(commitMessage);
+        while (m.find()) {
+            result.add(m.group(1));
+        }
+        return result;
     }
 
     // Metadata

--- a/src/test/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfCommitUtilsTest.java
+++ b/src/test/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfCommitUtilsTest.java
@@ -1,0 +1,24 @@
+package de.leipzig.htwk.gitrdf.worker.utils.rdf;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Set;
+
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.junit.jupiter.api.Test;
+
+public class RdfCommitUtilsTest {
+
+    @Test
+    void parseCommitMessageCreatesIssueTriple() {
+        String message = "Fixes #123";
+        Set<String> numbers = RdfCommitUtils.extractIssueNumbers(message);
+        assertTrue(numbers.contains("123"));
+
+        Triple t = RdfCommitUtils.createCommitIssueProperty("http://example.com/c1", "https://github.com/user/repo/issues/123");
+        assertEquals(NodeFactory.createURI("http://example.com/c1"), t.getSubject());
+        assertEquals(RdfCommitUtils.commitIssueProperty(), t.getPredicate());
+        assertEquals(NodeFactory.createURI("https://github.com/user/repo/issues/123"), t.getObject());
+    }
+}


### PR DESCRIPTION
## Summary
- add `commitIssueProperty` and helper triple creation
- extract GitHub issue numbers from commit messages
- link commits to referenced issues during conversion
- document new `github:issue` predicate
- add unit test for issue extraction and triple creation

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68612bb8d084832b8432775bc9041c6b