### PR TITLE
Limit PR linking to recent history

### DIFF
--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
@@ -1073,17 +1073,20 @@ public class GithubRdfConversionTransactionService {
                 () -> repo.queryPullRequests().state(GHIssueState.CLOSED).list(),
                 "queryPullRequests");
 
+        ZonedDateTime oneYearAgo = ZonedDateTime.now().minusYears(1);
+
         for (GHPullRequest pr : prs) {
             if (!pr.isMerged()) {
                 continue;
             }
 
-            String prUri = pr.getHtmlUrl().toString();
-            LocalDateTime mergedAt = null;
             Date merged = pr.getMergedAt();
-            if (merged != null) {
-                mergedAt = localDateTimeFrom(merged);
+            if (merged == null || merged.toInstant().isBefore(oneYearAgo.toInstant())) {
+                continue;
             }
+
+            String prUri = pr.getHtmlUrl().toString();
+            LocalDateTime mergedAt = localDateTimeFrom(merged);
 
             PullRequestInfo info = new PullRequestInfo(prUri, pr.getMergeCommitSha(), mergedAt);
 


### PR DESCRIPTION
## Summary
- only link commits to pull requests from the last year

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686162e41168832ba8983f92d9f21d51