### PR TITLE
Add workflow step name extraction

### DIFF
--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
@@ -68,6 +68,7 @@ import org.kohsuke.github.GHPullRequestReviewComment;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GHUser;
 import org.kohsuke.github.GHWorkflowJob;
+import org.kohsuke.github.GHWorkflowJob.Step;
 import org.kohsuke.github.GHWorkflowRun;
 import org.kohsuke.github.GitHub;
 import org.kohsuke.github.PagedIterable;
@@ -92,6 +93,7 @@ import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGithubIssueDiscussionUtils;
 import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGithubIssueReviewUtils;
 import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGithubIssueUtils;
 import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGithubWorkflowJobUtils;
+import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGithubWorkflowStepUtils;
 import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfGithubWorkflowUtils;
 import de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfTurtleTidier;
 import jakarta.persistence.EntityManager;
@@ -1572,6 +1574,20 @@ public class GithubRdfConversionTransactionService {
         if (job.getCompletedAt() != null) {
             writer.triple(RdfGithubWorkflowJobUtils.createWorkflowJobCompletedAtProperty(jobUri,
                     localDateTimeFrom(job.getCompletedAt())));
+        }
+
+        // Write step names with minimal information
+        List<Step> steps = job.getSteps();
+        if (steps != null) {
+            for (Step step : steps) {
+                String stepUri = jobUri + "/steps/" + step.getNumber();
+                writer.triple(RdfGithubWorkflowJobUtils.createWorkflowJobStepProperty(jobUri, stepUri));
+                writer.triple(RdfGithubWorkflowStepUtils.createWorkflowStepRdfTypeProperty(stepUri));
+                writer.triple(RdfGithubWorkflowStepUtils.createWorkflowStepNumberProperty(stepUri, step.getNumber()));
+                if (step.getName() != null) {
+                    writer.triple(RdfGithubWorkflowStepUtils.createWorkflowStepNameProperty(stepUri, step.getName()));
+                }
+            }
         }
     }
 

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubWorkflowStepUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubWorkflowStepUtils.java
@@ -1,0 +1,39 @@
+package de.leipzig.htwk.gitrdf.worker.utils.rdf;
+
+import static de.leipzig.htwk.gitrdf.worker.service.impl.GithubRdfConversionTransactionService.PLATFORM_GITHUB_NAMESPACE;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.Triple;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class RdfGithubWorkflowStepUtils {
+
+    private static final String GH_NS = PLATFORM_GITHUB_NAMESPACE + ":";
+
+    public static Node rdfTypeProperty() {
+        return RdfUtils.uri("rdf:type");
+    }
+
+    public static Node identifierProperty() { return RdfUtils.uri(GH_NS + "workflowStepId"); }
+    public static Node nameProperty() { return RdfUtils.uri(GH_NS + "workflowStepName"); }
+    public static Node numberProperty() { return RdfUtils.uri(GH_NS + "workflowStepNumber"); }
+
+    public static Triple createWorkflowStepRdfTypeProperty(String stepUri) {
+        return Triple.create(RdfUtils.uri(stepUri), rdfTypeProperty(), RdfUtils.uri("github:WorkflowStep"));
+    }
+
+    public static Triple createWorkflowStepIdProperty(String stepUri, long id) {
+        return Triple.create(RdfUtils.uri(stepUri), identifierProperty(), RdfUtils.longLiteral(id));
+    }
+
+    public static Triple createWorkflowStepNameProperty(String stepUri, String name) {
+        return Triple.create(RdfUtils.uri(stepUri), nameProperty(), RdfUtils.stringLiteral(name));
+    }
+
+    public static Triple createWorkflowStepNumberProperty(String stepUri, int number) {
+        return Triple.create(RdfUtils.uri(stepUri), numberProperty(), RdfUtils.integerLiteral(number));
+    }
+}


### PR DESCRIPTION
## Summary
- add `RdfGithubWorkflowStepUtils` to model workflow steps
- capture step names in `GithubRdfConversionTransactionService`

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68619bfc3d60832bb9c2063b44a17d49