### PR TITLE
Centralize GitHub URI utilities

### DIFF
--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/GithubUriUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/GithubUriUtils.java
@@ -1,0 +1,37 @@
+package de.leipzig.htwk.gitrdf.worker.utils;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * Utility methods for creating GitHub related URIs.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class GithubUriUtils {
+
+    private static final String GITHUB_BASE = "https://github.com/";
+
+    public static String getRepositoryUri(String owner, String repository) {
+        return GITHUB_BASE + owner + "/" + repository + "/";
+    }
+
+    public static String getCommitBaseUri(String owner, String repository) {
+        return GITHUB_BASE + owner + "/" + repository + "/commit/";
+    }
+
+    public static String getCommitUri(String owner, String repository, String commitHash) {
+        return getCommitBaseUri(owner, repository) + commitHash;
+    }
+
+    public static String getIssueBaseUri(String owner, String repository) {
+        return GITHUB_BASE + owner + "/" + repository + "/issues/";
+    }
+
+    public static String getIssueUri(String owner, String repository, String issueNumber) {
+        return getIssueBaseUri(owner, repository) + issueNumber;
+    }
+
+    public static String getUserUri(String userName) {
+        return GITHUB_BASE + userName;
+    }
+}

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGitCommitUserUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGitCommitUserUtils.java
@@ -6,6 +6,8 @@ import org.kohsuke.github.GHCommit;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GHUser;
 
+import de.leipzig.htwk.gitrdf.worker.utils.GithubUriUtils;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -34,7 +36,7 @@ public class RdfGitCommitUserUtils {
                 return null;
             }
 
-            return "https://github.com/" + login;
+            return GithubUriUtils.getUserUri(login);
         } catch (IOException e) {
             log.info("Could not retrieve github-user from commit hash '{}'", commitHash, e);
             return null;


### PR DESCRIPTION
## Summary
- add `GithubUriUtils` with helper methods for building GitHub URIs
- use these helpers in `RdfGitCommitUserUtils`
- replace inline URI creation inside `GithubRdfConversionTransactionService` with the utility
- remove now unused private URI builders from the service

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68628f9cdc3c832bac74bf2fc1d02978