### PR TITLE
Add RDF vocabulary v2 files

### DIFF
--- a/src/main/resources/rdf/v2/git2RDFLab-git-v2.ttl
+++ b/src/main/resources/rdf/v2/git2RDFLab-git-v2.ttl
@@ -1,0 +1,24 @@
+@prefix git: <https://git2rdf.example.com/git/v2/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+
+# Classes
+
+git:GitRepository a rdfs:Class ;
+    rdfs:label "Git repository" .
+
+git:GitSubmodule a rdfs:Class ;
+    rdfs:label "Git submodule" .
+
+# Properties
+
+git:hasSubmodule a rdf:Property ;
+    rdfs:label "has submodule" ;
+    rdfs:domain git:GitRepository ;
+    rdfs:range git:GitSubmodule .
+
+# Old property kept for compatibility
+
+git:submodule a rdf:Property ;
+    owl:equivalentProperty git:hasSubmodule .

--- a/src/main/resources/rdf/v2/git2RDFLab-platform-github-v2.ttl
+++ b/src/main/resources/rdf/v2/git2RDFLab-platform-github-v2.ttl
@@ -1,0 +1,27 @@
+@prefix platform: <https://git2rdf.example.com/platform/v2/> .
+@prefix github: <https://git2rdf.example.com/github/v2/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+
+# Classes
+
+github:PullRequest a rdfs:Class ;
+    rdfs:label "GitHub pull request" .
+
+# Properties
+
+github:mergedBy a rdf:Property ;
+    rdfs:label "merged by" ;
+    rdfs:domain github:PullRequest ;
+    rdfs:range platform:Person .
+
+github:pullRequestId a rdf:Property ;
+    rdfs:label "pull request identifier" ;
+    rdfs:domain github:PullRequest ;
+    rdfs:range rdfs:Literal .
+
+# Equivalent old names
+
+github:prId a rdf:Property ;
+    owl:equivalentProperty github:pullRequestId .

--- a/src/main/resources/rdf/v2/git2RDFLab-platform-v2.ttl
+++ b/src/main/resources/rdf/v2/git2RDFLab-platform-v2.ttl
@@ -1,0 +1,24 @@
+@prefix platform: <https://git2rdf.example.com/platform/v2/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+
+# Classes
+
+platform:Person a rdfs:Class ;
+    rdfs:label "Platform person" .
+
+platform:Repository a rdfs:Class ;
+    rdfs:label "Platform repository" .
+
+# Properties
+
+platform:owner a rdf:Property ;
+    rdfs:label "owner" ;
+    rdfs:domain platform:Repository ;
+    rdfs:range platform:Person .
+
+# Old property kept for backward compatibility
+
+platform:repositoryOwner a rdf:Property ;
+    owl:equivalentProperty platform:owner .

--- a/src/main/resources/rdf/v2/git2RDFLab-workflows-v2.ttl
+++ b/src/main/resources/rdf/v2/git2RDFLab-workflows-v2.ttl
@@ -1,0 +1,24 @@
+@prefix wf: <https://git2rdf.example.com/workflows/v2/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+
+# Classes
+
+wf:Workflow a rdfs:Class ;
+    rdfs:label "Workflow" .
+
+wf:WorkflowRun a rdfs:Class ;
+    rdfs:label "Workflow run" .
+
+# Properties
+
+wf:runOf a rdf:Property ;
+    rdfs:label "run of" ;
+    rdfs:domain wf:WorkflowRun ;
+    rdfs:range wf:Workflow .
+
+# Renamed property for compatibility
+
+wf:workflowRunOf a rdf:Property ;
+    owl:equivalentProperty wf:runOf .


### PR DESCRIPTION
## Summary
- define Git vocabulary in `git2RDFLab-git-v2.ttl`
- define generic platform vocabulary in `git2RDFLab-platform-v2.ttl`
- add GitHub-specific vocabulary in `git2RDFLab-platform-github-v2.ttl`
- add workflow vocabulary in `git2RDFLab-workflows-v2.ttl`

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68701e5ad690832bab6554436da5694a