### PR TITLE
Align RDF utilities with v2 ontology

### DIFF
--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
@@ -115,12 +115,12 @@ public class GithubRdfConversionTransactionService {
     // TODO: replace PURL
 
     public static final String GIT_NAMESPACE = "git";
-    public static final String GIT_URI = "https://purl.archive.org/git2rdflab/v1/git2RDFLab-git#";
+    public static final String GIT_URI = "https://purl.archive.org/git2rdflab/v2/git2RDFLab-git#";
 
     public static final String PLATFORM_NAMESPACE = "platform";
-    public static final String PLATFORM_URI = "https://purl.archive.org/git2rdflab/v1/git2RDFLab-platform#";
+    public static final String PLATFORM_URI = "https://purl.archive.org/git2rdflab/v2/git2RDFLab-platform#";
 
-    public static final String PLATFORM_GITHUB_URI = "https://purl.archive.org/git2rdflab/v1/git2RDFLab-platform-github#";
+    public static final String PLATFORM_GITHUB_URI = "https://purl.archive.org/git2rdflab/v2/git2RDFLab-platform-github#";
     public static final String PLATFORM_GITHUB_NAMESPACE = "github";
 
     public static final String XSD_SCHEMA_URI = "http://www.w3.org/2001/XMLSchema#";

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubCommentUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubCommentUtils.java
@@ -1,6 +1,7 @@
 package de.leipzig.htwk.gitrdf.worker.utils.rdf;
 
 import static de.leipzig.htwk.gitrdf.worker.service.impl.GithubRdfConversionTransactionService.PLATFORM_GITHUB_NAMESPACE;
+import static de.leipzig.htwk.gitrdf.worker.service.impl.GithubRdfConversionTransactionService.PLATFORM_NAMESPACE;
 import static de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfUtils.uri;
 
 import java.time.LocalDateTime;
@@ -15,6 +16,7 @@ import lombok.NoArgsConstructor;
 public final class RdfGithubCommentUtils {
 
   private static final String GH_NS = PLATFORM_GITHUB_NAMESPACE + ":";
+  private static final String PF_NS = PLATFORM_NAMESPACE + ":";
 
   // Core RDF properties
   public static Node rdfTypeProperty() {
@@ -23,23 +25,23 @@ public final class RdfGithubCommentUtils {
 
   // Comment identification and basic properties
   public static Node commentIdProperty() {
-    return uri(GH_NS + "commentId");
+    return uri(PF_NS + "commentId");
   }
 
   public static Node commentHtmlUrlProperty() {
-    return uri(GH_NS + "commentHtmlUrl");
+    return uri(PF_NS + "commentUrl");
   }
 
   public static Node commentBodyProperty() {
-    return uri(GH_NS + "commentBody");
+    return uri(PF_NS + "commentBody");
   }
 
   public static Node commentUserProperty() {
-    return uri(GH_NS + "user");
+    return uri(PF_NS + "commentAuthor");
   }
 
   public static Node commentCreatedAtProperty() {
-    return uri(GH_NS + "submittedAt");
+    return uri(PF_NS + "commentedAt");
   }
 
   public static Node commentUpdatedAtProperty() {
@@ -48,7 +50,7 @@ public final class RdfGithubCommentUtils {
 
   // Threading and hierarchy properties
   public static Node isRootCommentProperty() {
-    return uri(GH_NS + "isRootComment");
+    return uri(PF_NS + "isRootComment");
   }
 
   public static Node parentCommentProperty() {
@@ -83,7 +85,7 @@ public final class RdfGithubCommentUtils {
   }
 
   public static Node reactionCountProperty() {
-    return uri(GH_NS + "reactionCount");
+    return uri(PF_NS + "reactionCount");
   }
 
   public static Node reactionProperty() {

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubIssueUtils.java
@@ -23,29 +23,29 @@ public final class RdfGithubIssueUtils {
     }
 
     public static Node titleProperty() {
-        return RdfUtils.uri(PLATFORM_NS + "ticketTitle");
+        return RdfUtils.uri(PLATFORM_NS + "title");
     }
 
     public static Node bodyProperty() {
-        return RdfUtils.uri(PLATFORM_NS + "ticketBody");
+        return RdfUtils.uri(PLATFORM_NS + "body");
     }
 
     // Platform - GitHub
 
     public static Node numberProperty() {
-        return RdfUtils.uri(GH_NS + "number");
+        return RdfUtils.uri(PLATFORM_NS + "number");
     }
 
     public static Node stateProperty() {
-        return RdfUtils.uri(GH_NS + "state");
+        return RdfUtils.uri(PLATFORM_NS + "state");
     }
 
     public static Node userProperty() {
-        return RdfUtils.uri(GH_NS + "user");
+        return RdfUtils.uri(PLATFORM_NS + "submitter");
     }
 
     public static Node assigneeProperty() {
-        return RdfUtils.uri(GH_NS + "assignee");
+        return RdfUtils.uri(PLATFORM_NS + "assignee");
     }
 
     public static Node requestedReviewerProperty() {
@@ -53,19 +53,19 @@ public final class RdfGithubIssueUtils {
     }
 
     public static Node milestoneProperty() {
-        return RdfUtils.uri(GH_NS + "milestone");
+        return RdfUtils.uri(PLATFORM_NS + "hasMilestone");
     }
 
     public static Node submittedAtProperty() {
-        return RdfUtils.uri(GH_NS + "submittedAt");
+        return RdfUtils.uri(PLATFORM_NS + "createdAt");
     }
 
     public static Node updatedAtProperty() {
-        return RdfUtils.uri(GH_NS + "updatedAt");
+        return RdfUtils.uri(PLATFORM_NS + "updatedAt");
     }
 
     public static Node closedAtProperty() {
-        return RdfUtils.uri(GH_NS + "closedAt");
+        return RdfUtils.uri(PLATFORM_NS + "closedAt");
     }
 
     // Merge information
@@ -104,7 +104,7 @@ public final class RdfGithubIssueUtils {
     }
 
     public static Triple createIssueStateProperty(String issueUri, String state) {
-        return Triple.create(RdfUtils.uri(issueUri), stateProperty(), RdfUtils.uri(GH_NS + state.toLowerCase()));
+        return Triple.create(RdfUtils.uri(issueUri), stateProperty(), RdfUtils.uri(PLATFORM_NS + state.toLowerCase()));
     }
 
     public static Triple createIssueTitleProperty(String issueUri, String title) {

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubWorkflowJobUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubWorkflowJobUtils.java
@@ -1,6 +1,7 @@
 package de.leipzig.htwk.gitrdf.worker.utils.rdf;
 
 import static de.leipzig.htwk.gitrdf.worker.service.impl.GithubRdfConversionTransactionService.PLATFORM_GITHUB_NAMESPACE;
+import static de.leipzig.htwk.gitrdf.worker.service.impl.GithubRdfConversionTransactionService.PLATFORM_NAMESPACE;
 
 import java.time.LocalDateTime;
 
@@ -15,17 +16,18 @@ import lombok.NoArgsConstructor;
 public final class RdfGithubWorkflowJobUtils {
 
     private static final String GH_NS = PLATFORM_GITHUB_NAMESPACE + ":";
+    private static final String PF_NS = PLATFORM_NAMESPACE + ":";
 
     public static Node rdfTypeProperty() {
         return RdfUtils.uri("rdf:type");
     }
 
     public static Node identifierProperty() { return RdfUtils.uri(GH_NS + "workflowJobId"); }
-    public static Node nameProperty() { return RdfUtils.uri(GH_NS + "workflowJobName"); }
-    public static Node statusProperty() { return RdfUtils.uri(GH_NS + "workflowJobStatus"); }
-    public static Node conclusionProperty() { return RdfUtils.uri(GH_NS + "workflowJobConclusion"); }
-    public static Node startedAtProperty() { return RdfUtils.uri(GH_NS + "workflowJobStartedAt"); }
-    public static Node completedAtProperty() { return RdfUtils.uri(GH_NS + "workflowJobCompletedAt"); }
+    public static Node nameProperty() { return RdfUtils.uri(PF_NS + "jobName"); }
+    public static Node statusProperty() { return RdfUtils.uri(PF_NS + "jobStatus"); }
+    public static Node conclusionProperty() { return RdfUtils.uri(PF_NS + "jobConclusion"); }
+    public static Node startedAtProperty() { return RdfUtils.uri(PF_NS + "jobStartedAt"); }
+    public static Node completedAtProperty() { return RdfUtils.uri(PF_NS + "jobCompletedAt"); }
     public static Node jobUrlProperty() { return RdfUtils.uri(GH_NS + "workflowJobUrl"); }
     public static Node stepProperty() { return RdfUtils.uri(GH_NS + "workflowStep"); }
     
@@ -44,11 +46,11 @@ public final class RdfGithubWorkflowJobUtils {
     }
 
     public static Triple createWorkflowJobStatusProperty(String jobUri, GHWorkflowRun.Status status) {
-        return Triple.create(RdfUtils.uri(jobUri), statusProperty(), RdfUtils.uri(GH_NS + status));
+        return Triple.create(RdfUtils.uri(jobUri), statusProperty(), RdfUtils.uri(PF_NS + status));
     }
 
     public static Triple createWorkflowJobConclusionProperty(String jobUri, GHWorkflowRun.Conclusion conclusion) {
-        return Triple.create(RdfUtils.uri(jobUri), conclusionProperty(), RdfUtils.uri(GH_NS + conclusion));
+        return Triple.create(RdfUtils.uri(jobUri), conclusionProperty(), RdfUtils.uri(PF_NS + conclusion));
     }
 
     public static Triple createWorkflowJobStartedAtProperty(String jobUri, LocalDateTime started) {

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubWorkflowUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubWorkflowUtils.java
@@ -1,6 +1,7 @@
 package de.leipzig.htwk.gitrdf.worker.utils.rdf;
 
 import static de.leipzig.htwk.gitrdf.worker.service.impl.GithubRdfConversionTransactionService.PLATFORM_GITHUB_NAMESPACE;
+import static de.leipzig.htwk.gitrdf.worker.service.impl.GithubRdfConversionTransactionService.PLATFORM_NAMESPACE;
 
 import java.time.LocalDateTime;
 
@@ -15,14 +16,21 @@ import lombok.NoArgsConstructor;
 public final class RdfGithubWorkflowUtils {
 
     private static final String GH_NS = PLATFORM_GITHUB_NAMESPACE + ":";
+    private static final String PF_NS = PLATFORM_NAMESPACE + ":";
 
     public static Node rdfTypeProperty() {
         return RdfUtils.uri("rdf:type");
     }
 
+    // Platform based properties
+    public static Node nameProperty() { return RdfUtils.uri(PF_NS + "workflowName"); }
+    public static Node descriptionProperty() { return RdfUtils.uri(PF_NS + "workflowDescription"); }
+    public static Node triggerProperty() { return RdfUtils.uri(PF_NS + "workflowTrigger"); }
+    public static Node jobProperty() { return RdfUtils.uri(PF_NS + "hasJob"); }
+
+    // GitHub specific run related properties
     public static Node workflowRunProperty() { return RdfUtils.uri(GH_NS + "workflowRun"); }
     public static Node identifierProperty() { return RdfUtils.uri(GH_NS + "workflowRunId"); }
-    public static Node nameProperty() { return RdfUtils.uri(GH_NS + "workflowName"); }
     public static Node statusProperty() { return RdfUtils.uri(GH_NS + "workflowStatus"); }
     public static Node conclusionProperty() { return RdfUtils.uri(GH_NS + "workflowConclusion"); }
     public static Node eventProperty() { return RdfUtils.uri(GH_NS + "workflowEvent"); }
@@ -30,7 +38,6 @@ public final class RdfGithubWorkflowUtils {
     public static Node commitShaProperty() { return RdfUtils.uri(GH_NS + "workflowCommitSha"); }
     public static Node createdAtProperty() { return RdfUtils.uri(GH_NS + "workflowCreatedAt"); }
     public static Node updatedAtProperty() { return RdfUtils.uri(GH_NS + "workflowUpdatedAt"); }
-    public static Node jobProperty() { return RdfUtils.uri(GH_NS + "workflowJob"); }
 
     // Triple creation
     public static Triple createWorkflowRunProperty(String issueUri, String runUri) {
@@ -47,6 +54,14 @@ public final class RdfGithubWorkflowUtils {
 
     public static Triple createWorkflowNameProperty(String runUri, String name) {
         return Triple.create(RdfUtils.uri(runUri), nameProperty(), RdfUtils.stringLiteral(name));
+    }
+
+    public static Triple createWorkflowDescriptionProperty(String runUri, String description) {
+        return Triple.create(RdfUtils.uri(runUri), descriptionProperty(), RdfUtils.stringLiteral(description));
+    }
+
+    public static Triple createWorkflowTriggerProperty(String runUri, String trigger) {
+        return Triple.create(RdfUtils.uri(runUri), triggerProperty(), RdfUtils.stringLiteral(trigger));
     }
 
     public static Triple createWorkflowStatusProperty(String runUri, GHWorkflowRun.Status status) {


### PR DESCRIPTION
## Summary
- switch base ontology URIs to v2
- update Github issue utilities to new platform property names
- update workflow/job utilities to use platform vocabulary
- adjust comment utilities to new comment properties

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687024bef550832b83a251679d51beb3