### PR TITLE
Align worker with v2 RDF schema

### DIFF
--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/GithubUriUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/GithubUriUtils.java
@@ -29,6 +29,20 @@ public final class GithubUriUtils {
         return getCommitBaseUri(owner, repository) + commitHash;
     }
 
+    /**
+     * Build a URI for a branch within a repository.
+     */
+    public static String getBranchUri(String owner, String repository, String branchName) {
+        return GITHUB_BASE + owner + "/" + repository + "/tree/" + branchName;
+    }
+
+    /**
+     * Build a URI for a tag within a repository.
+     */
+    public static String getTagUri(String owner, String repository, String tagName) {
+        return GITHUB_BASE + owner + "/" + repository + "/tree/" + tagName;
+    }
+
     public static String getPullRequestUri(String prUrl) {
         return prUrl;
     }

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/GithubUserInfo.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/GithubUserInfo.java
@@ -1,0 +1,18 @@
+package de.leipzig.htwk.gitrdf.worker.utils.rdf;
+
+/**
+ * Simple container for GitHub user details.
+ */
+public class GithubUserInfo {
+    public final String uri;
+    public final String login;
+    public final long userId;
+    public final String name;
+
+    public GithubUserInfo(String uri, String login, long userId, String name) {
+        this.uri = uri;
+        this.login = login;
+        this.userId = userId;
+        this.name = name;
+    }
+}

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfCommitUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfCommitUtils.java
@@ -105,6 +105,18 @@ public final class RdfCommitUtils {
         return uri(NS + "branchName");
     }
 
+    public static Node inBranchProperty() { return uri(NS + "inBranch"); }
+
+    public static Node hasTagProperty() { return uri(NS + "hasTag"); }
+
+    public static Node repositoryHasCommitProperty() { return uri(NS + "hasCommit"); }
+
+    public static Node repositoryHasBranchProperty() { return uri(NS + "hasBranch"); }
+
+    public static Node branchHeadCommitProperty() { return uri(NS + "headCommit"); }
+
+    public static Node tagPointsToProperty() { return uri(NS + "pointsTo"); }
+
     public static Node commitDiffEntryEditTypeProperty() {
         return uri(NS + "changeType");
     }
@@ -234,6 +246,9 @@ public final class RdfCommitUtils {
     public static Node commitTagNameProperty() {
         return uri(NS + "tagName");
     }
+
+    public static Node branchNameProperty() { return commitBranchNameProperty(); }
+
 
 
     // Branch Snapshot
@@ -387,6 +402,47 @@ public final class RdfCommitUtils {
 
     public static Triple createCommitTagProperty(String commitUri, String tagName) {
         return Triple.create(uri(commitUri), commitTagNameProperty(), stringLiteral(tagName));
+    }
+
+    // New relationships using v2 schema
+    public static Triple createCommitInBranchProperty(String commitUri, String branchUri) {
+        return Triple.create(uri(commitUri), inBranchProperty(), uri(branchUri));
+    }
+
+    public static Triple createCommitHasTagProperty(String commitUri, String tagUri) {
+        return Triple.create(uri(commitUri), hasTagProperty(), uri(tagUri));
+    }
+
+    public static Triple createRepositoryHasCommitProperty(String repoUri, String commitUri) {
+        return Triple.create(uri(repoUri), repositoryHasCommitProperty(), uri(commitUri));
+    }
+
+    public static Triple createRepositoryHasBranchProperty(String repoUri, String branchUri) {
+        return Triple.create(uri(repoUri), repositoryHasBranchProperty(), uri(branchUri));
+    }
+
+    public static Triple createBranchRdfTypeProperty(String branchUri) {
+        return Triple.create(uri(branchUri), rdfTypeProperty(), uri(NS + "GitBranch"));
+    }
+
+    public static Triple createBranchNameProperty(String branchUri, String name) {
+        return Triple.create(uri(branchUri), branchNameProperty(), stringLiteral(name));
+    }
+
+    public static Triple createBranchHeadCommitProperty(String branchUri, String commitUri) {
+        return Triple.create(uri(branchUri), branchHeadCommitProperty(), uri(commitUri));
+    }
+
+    public static Triple createTagRdfTypeProperty(String tagUri) {
+        return Triple.create(uri(tagUri), rdfTypeProperty(), uri(NS + "GitTag"));
+    }
+
+    public static Triple createTagNameProperty(String tagUri, String tagName) {
+        return Triple.create(uri(tagUri), commitTagNameProperty(), stringLiteral(tagName));
+    }
+
+    public static Triple createTagPointsToProperty(String tagUri, String commitUri) {
+        return Triple.create(uri(tagUri), tagPointsToProperty(), uri(commitUri));
     }
 
     public static Triple createCommitPartOfIssueProperty(String commitUri, String issueUri) {

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubUserUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfGithubUserUtils.java
@@ -1,0 +1,38 @@
+package de.leipzig.htwk.gitrdf.worker.utils.rdf;
+
+import static de.leipzig.htwk.gitrdf.worker.service.impl.GithubRdfConversionTransactionService.PLATFORM_GITHUB_NAMESPACE;
+import static de.leipzig.htwk.gitrdf.worker.service.impl.GithubRdfConversionTransactionService.PLATFORM_NAMESPACE;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.Triple;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class RdfGithubUserUtils {
+
+    private static final String GH_NS = PLATFORM_GITHUB_NAMESPACE + ":";
+    private static final String PF_NS = PLATFORM_NAMESPACE + ":";
+
+    public static Node rdfTypeProperty() { return RdfUtils.uri("rdf:type"); }
+    public static Node loginProperty() { return RdfUtils.uri(GH_NS + "login"); }
+    public static Node userIdProperty() { return RdfUtils.uri(GH_NS + "userId"); }
+    public static Node nameProperty() { return RdfUtils.uri(PF_NS + "name"); }
+
+    public static Triple createGitHubUserType(String userUri) {
+        return Triple.create(RdfUtils.uri(userUri), rdfTypeProperty(), RdfUtils.uri("github:GitHubUser"));
+    }
+
+    public static Triple createLoginProperty(String userUri, String login) {
+        return Triple.create(RdfUtils.uri(userUri), loginProperty(), RdfUtils.stringLiteral(login));
+    }
+
+    public static Triple createUserIdProperty(String userUri, long id) {
+        return Triple.create(RdfUtils.uri(userUri), userIdProperty(), RdfUtils.nonNegativeIntegerLiteral(id));
+    }
+
+    public static Triple createNameProperty(String userUri, String name) {
+        return Triple.create(RdfUtils.uri(userUri), nameProperty(), RdfUtils.stringLiteral(name));
+    }
+}


### PR DESCRIPTION
## Summary
- generate branch and tag URIs and expose helpers
- model GitHub user details for commits
- add repository–commit/branch links and commit branch/tag relations
- include branch and tag resources in output
- separate GithubUserInfo data class

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687030a01ed8832baf498aca8669c6b8