### PR TITLE
Fix repository owner as resource

### DIFF
--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
@@ -429,7 +429,17 @@ public class GithubRdfConversionTransactionService {
 
             writer.start();
             writer.triple(RdfCommitUtils.createRepositoryRdfTypeProperty(repositoryUri));
-            writer.triple(RdfCommitUtils.createRepositoryOwnerProperty(repositoryUri, owner));
+            String ownerUri = GithubUriUtils.getUserUri(owner);
+            writer.triple(RdfCommitUtils.createRepositoryOwnerProperty(repositoryUri, ownerUri));
+            GHUser repoOwner = githubRepositoryHandle.getOwner();
+            if (repoOwner != null) {
+                writer.triple(RdfGithubUserUtils.createGitHubUserType(ownerUri));
+                writer.triple(RdfGithubUserUtils.createLoginProperty(ownerUri, repoOwner.getLogin()));
+                writer.triple(RdfGithubUserUtils.createUserIdProperty(ownerUri, repoOwner.getId()));
+                if (repoOwner.getName() != null && !repoOwner.getName().isEmpty()) {
+                    writer.triple(RdfGithubUserUtils.createNameProperty(ownerUri, repoOwner.getName()));
+                }
+            }
             writer.triple(RdfCommitUtils.createRepositoryNameProperty(repositoryUri, repositoryName));
 
             Config config = gitRepository.getConfig();

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfCommitUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfCommitUtils.java
@@ -500,8 +500,8 @@ public final class RdfCommitUtils {
         return Triple.create(uri(repoUri), repositoryEncodingProperty(), stringLiteral(encoding));
     }
 
-    public static Triple createRepositoryOwnerProperty(String repoUri, String ownerName) {
-        return Triple.create(uri(repoUri), repositoryOwnerProperty(), stringLiteral(ownerName));
+    public static Triple createRepositoryOwnerProperty(String repoUri, String ownerUri) {
+        return Triple.create(uri(repoUri), repositoryOwnerProperty(), uri(ownerUri));
     }
 
     public static Triple createRepositoryNameProperty(String repoUri, String repositoryName) {


### PR DESCRIPTION
## Summary
- treat repository owner as a GitHubUser URI instead of a string
- write GitHubUser triples for repository owner metadata

## Testing
- `sh mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68718461fa60832b9a5d3c7671fbe61b