### PR TITLE
Fix tag URIs and add owl:sameAs link

### DIFF
--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/service/impl/GithubRdfConversionTransactionService.java
@@ -131,6 +131,9 @@ public class GithubRdfConversionTransactionService {
     public static final String RDF_SCHEMA_NAMESPACE = "rdf";
     public static final String RDF_SCHEMA_URI = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
 
+    public static final String OWL_SCHEMA_NAMESPACE = "owl";
+    public static final String OWL_SCHEMA_URI = "http://www.w3.org/2002/07/owl#";
+
     private final GithubHandlerService githubHandlerService;
 
     private final GithubConfig githubConfig;
@@ -395,6 +398,7 @@ public class GithubRdfConversionTransactionService {
 
             writer.prefix(XSD_SCHEMA_NAMESPACE, XSD_SCHEMA_URI);
             writer.prefix(RDF_SCHEMA_NAMESPACE, RDF_SCHEMA_URI);
+            writer.prefix(OWL_SCHEMA_NAMESPACE, OWL_SCHEMA_URI);
             writer.prefix(GIT_NAMESPACE, GIT_URI);
             writer.prefix(PLATFORM_NAMESPACE, PLATFORM_URI);
             writer.prefix(PLATFORM_GITHUB_NAMESPACE, PLATFORM_GITHUB_URI);
@@ -684,10 +688,12 @@ public class GithubRdfConversionTransactionService {
                         if (tagNames != null && !tagNames.isEmpty()) {
                             for (String tagName : tagNames) {
                                 String tagUri = GithubUriUtils.getTagUri(owner, repositoryName, tagName);
+                                String tagUrl = GithubUriUtils.getTagUrl(owner, repositoryName, tagName);
                                 writer.triple(RdfCommitUtils.createCommitHasTagProperty(commitUri, tagUri));
                                 writer.triple(RdfCommitUtils.createTagRdfTypeProperty(tagUri));
                                 writer.triple(RdfCommitUtils.createTagNameProperty(tagUri, tagName));
                                 writer.triple(RdfCommitUtils.createTagPointsToProperty(tagUri, commitUri));
+                                writer.triple(RdfCommitUtils.createTagSameAsProperty(tagUri, tagUrl));
                                 log.debug("Added Tag '{}' to commit #{}", tagName, commitId.getName());
                             }
                         }

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/GithubUriUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/GithubUriUtils.java
@@ -34,7 +34,11 @@ public final class GithubUriUtils {
     }
 
     public static String getTagUri(String owner, String repository, String tagName) {
-        return GITHUB_BASE + owner + "/" + repository + "/tree/" + tagName;
+        return GITHUB_BASE + owner + "/" + repository + "/tags/" + tagName;
+    }
+
+    public static String getTagUrl(String owner, String repository, String tagName) {
+        return GITHUB_API_BASE + "repos/" + owner + "/" + repository + "/git/tags/" + tagName;
     }
 
     public static String getPullRequestUri(String prUrl) {

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfCommitUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfCommitUtils.java
@@ -4,6 +4,7 @@ import static de.leipzig.htwk.gitrdf.worker.service.impl.GithubRdfConversionTran
 import static de.leipzig.htwk.gitrdf.worker.service.impl.GithubRdfConversionTransactionService.PLATFORM_GITHUB_NAMESPACE;
 import static de.leipzig.htwk.gitrdf.worker.service.impl.GithubRdfConversionTransactionService.PLATFORM_NAMESPACE;
 import static de.leipzig.htwk.gitrdf.worker.service.impl.GithubRdfConversionTransactionService.RDF_SCHEMA_NAMESPACE;
+import static de.leipzig.htwk.gitrdf.worker.service.impl.GithubRdfConversionTransactionService.OWL_SCHEMA_NAMESPACE;
 import static de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfUtils.dateTimeLiteral;
 import static de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfUtils.stringLiteral;
 import static de.leipzig.htwk.gitrdf.worker.utils.rdf.RdfUtils.uri;
@@ -31,6 +32,7 @@ public final class RdfCommitUtils {
     private static final String GH_NS = PLATFORM_GITHUB_NAMESPACE + ":";
     private static final String PF_NS = PLATFORM_NAMESPACE + ":";
     private static final String RDF_NS = RDF_SCHEMA_NAMESPACE + ":";
+    private static final String OWL_NS = OWL_SCHEMA_NAMESPACE + ":";
 
 
     // org.apache.jena.datatypes.xsd.XSDDatatype -> static xsd Datatype collection from apache jena
@@ -116,6 +118,8 @@ public final class RdfCommitUtils {
     public static Node branchHeadCommitProperty() { return uri(NS + "headCommit"); }
 
     public static Node tagPointsToProperty() { return uri(NS + "pointsTo"); }
+
+    public static Node owlSameAsProperty() { return uri(OWL_NS + "sameAs"); }
 
     public static Node commitDiffEntryEditTypeProperty() {
         return uri(NS + "changeType");
@@ -443,6 +447,10 @@ public final class RdfCommitUtils {
 
     public static Triple createTagPointsToProperty(String tagUri, String commitUri) {
         return Triple.create(uri(tagUri), tagPointsToProperty(), uri(commitUri));
+    }
+
+    public static Triple createTagSameAsProperty(String tagUri, String tagUrl) {
+        return Triple.create(uri(tagUri), owlSameAsProperty(), uri(tagUrl));
     }
 
     public static Triple createCommitPartOfIssueProperty(String commitUri, String issueUri) {

--- a/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfUtils.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/worker/utils/rdf/RdfUtils.java
@@ -10,6 +10,8 @@ import static de.leipzig.htwk.gitrdf.worker.service.impl.GithubRdfConversionTran
 import static de.leipzig.htwk.gitrdf.worker.service.impl.GithubRdfConversionTransactionService.RDF_SCHEMA_URI;
 import static de.leipzig.htwk.gitrdf.worker.service.impl.GithubRdfConversionTransactionService.XSD_SCHEMA_NAMESPACE;
 import static de.leipzig.htwk.gitrdf.worker.service.impl.GithubRdfConversionTransactionService.XSD_SCHEMA_URI;
+import static de.leipzig.htwk.gitrdf.worker.service.impl.GithubRdfConversionTransactionService.OWL_SCHEMA_NAMESPACE;
+import static de.leipzig.htwk.gitrdf.worker.service.impl.GithubRdfConversionTransactionService.OWL_SCHEMA_URI;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -32,10 +34,11 @@ public final class RdfUtils {
 
     private static final PrefixMap prefixMap = PrefixMapFactory.create(new HashMap<>(Map.of(// instead of Map.of
             GIT_NAMESPACE, GIT_URI,
-            PLATFORM_NAMESPACE,PLATFORM_URI,
-            PLATFORM_GITHUB_NAMESPACE,PLATFORM_GITHUB_URI,
-            XSD_SCHEMA_NAMESPACE,XSD_SCHEMA_URI,
-            RDF_SCHEMA_NAMESPACE,RDF_SCHEMA_URI
+            PLATFORM_NAMESPACE, PLATFORM_URI,
+            PLATFORM_GITHUB_NAMESPACE, PLATFORM_GITHUB_URI,
+            XSD_SCHEMA_NAMESPACE, XSD_SCHEMA_URI,
+            RDF_SCHEMA_NAMESPACE, RDF_SCHEMA_URI,
+            OWL_SCHEMA_NAMESPACE, OWL_SCHEMA_URI
     )));
 
     private static DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");


### PR DESCRIPTION
## Summary
- correct Git tag URIs and expose API URL via `getTagUrl`
- add owl namespace and `owl:sameAs` triples for tags
- register owl prefix in output and utility prefix map

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68742f63f120832bbe18a7cf87b576ad